### PR TITLE
feat: add endAdornment support to SelectInput

### DIFF
--- a/docs/src/pages/SelectInputDocs.tsx
+++ b/docs/src/pages/SelectInputDocs.tsx
@@ -17,10 +17,35 @@ const cityOptions = [
   { label: "Hyderabad", value: "hyderabad" },
 ];
 
+const vendorOptions = [
+  { label: "Saigon Interior Solutions Co., Ltd", value: "saigon" },
+  { label: "Hanoi FitOut JSC", value: "hanoi" },
+];
+
+// A small pill used to demonstrate `endAdornment` (e.g. a match indicator).
+const MatchedChip = () => (
+  <Box
+    sx={{
+      display: "inline-flex",
+      alignItems: "center",
+      px: "8px",
+      height: "20px",
+      borderRadius: "999px",
+      bgcolor: "#E6F4EA",
+      border: "1px solid #9AD0A9",
+    }}
+  >
+    <Typography sx={{ fontSize: "11px", fontWeight: 600, color: "#1E7B3C" }}>
+      Matched
+    </Typography>
+  </Box>
+);
+
 const SelectInputDocs: React.FC = () => {
   const [status, setStatus] = useState("");
   const [city, setCity] = useState("");
   const [errorVal, setErrorVal] = useState("");
+  const [vendor, setVendor] = useState("saigon");
 
   return (
     <Box>
@@ -94,6 +119,31 @@ const [status, setStatus] = useState('');
   options={cityOptions}
   placeholder="Choose a city"
   startAdornment={<Bank size={16} fill="#6B7280" />}
+/>`}
+        />
+      </DocSection>
+
+      <DocSection title="With End Adornment">
+        <ExampleBox>
+          <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+            <SelectInput
+              label="Vendor Name"
+              value={vendor}
+              onChange={(e) => setVendor(e.target.value)}
+              options={vendorOptions}
+              endAdornment={<MatchedChip />}
+            />
+          </Stack>
+        </ExampleBox>
+        <CodeBlock
+          code={`// endAdornment renders just before the dropdown arrow — pass any node
+// (a chip, badge, icon, spinner, etc.).
+<SelectInput
+  label="Vendor Name"
+  value={vendor}
+  onChange={(e) => setVendor(e.target.value)}
+  options={vendorOptions}
+  endAdornment={<MatchedChip />}
 />`}
         />
       </DocSection>
@@ -244,6 +294,12 @@ const [status, setStatus] = useState('');
               name: "startAdornment",
               type: "React.ReactNode",
               description: "Element displayed at the start of the select",
+            },
+            {
+              name: "endAdornment",
+              type: "React.ReactNode",
+              description:
+                "Element displayed at the end of the select, just before the dropdown arrow",
             },
             {
               name: "labelSx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipspacesit/fs-ui",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Flipspaces shared UI component library",
   "type": "module",
   "main": "./dist/fs-ui.cjs.js",

--- a/src/components/SelectInput/index.tsx
+++ b/src/components/SelectInput/index.tsx
@@ -79,6 +79,7 @@ export const SelectInput = <T = unknown,>({
   showSelectedIcon = true,
   size = "medium",
   startAdornment,
+  endAdornment,
   labelSx,
   helperTextSx,
   menuPaperSx,
@@ -168,42 +169,75 @@ export const SelectInput = <T = unknown,>({
           </Box>
         }
         forcePopupIcon
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            size={size}
-            autoFocus={false}
-            sx={inputSx}
-            placeholder={!selectedOption ? placeholder : undefined}
-            required={required}
-            error={props.error}
-            InputProps={{
-              ...params.InputProps,
-              startAdornment: startAdornment ? (
-                <Box display='flex' alignItems='center'>
-                  {startAdornment}
-                </Box>
-              ) : null,
-              sx: {
-                paddingLeft: startAdornment ? "10px" : undefined,
-                cursor: "pointer",
-                "& .MuiInputBase-input": {
+        renderInput={(params) => {
+          // MUI renders the dropdown arrow (and clear icon) inside its own
+          // absolutely-positioned wrapper. Unwrap those indicators so a custom
+          // `endAdornment` can sit next to the arrow in a single right-anchored
+          // row instead of overlapping it.
+          const autocompleteEnd = params.InputProps.endAdornment;
+          const arrowIndicators = React.isValidElement<{
+            children?: React.ReactNode;
+          }>(autocompleteEnd)
+            ? autocompleteEnd.props.children
+            : autocompleteEnd;
+          return (
+            <TextField
+              {...params}
+              size={size}
+              autoFocus={false}
+              sx={inputSx}
+              placeholder={!selectedOption ? placeholder : undefined}
+              required={required}
+              error={props.error}
+              InputProps={{
+                ...params.InputProps,
+                startAdornment: startAdornment ? (
+                  <Box display='flex' alignItems='center'>
+                    {startAdornment}
+                  </Box>
+                ) : null,
+                endAdornment:
+                  endAdornment || arrowIndicators ? (
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        right: "9px",
+                        top: "50%",
+                        transform: "translateY(-50%)",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "4px",
+                      }}
+                    >
+                      {endAdornment && (
+                        <Box display='flex' alignItems='center'>
+                          {endAdornment}
+                        </Box>
+                      )}
+                      {arrowIndicators}
+                    </Box>
+                  ) : null,
+                sx: {
+                  paddingLeft: startAdornment ? "10px" : undefined,
                   cursor: "pointer",
-                  caretColor: "transparent",
-                  userSelect: "none",
+                  "& .MuiInputBase-input": {
+                    cursor: "pointer",
+                    caretColor: "transparent",
+                    userSelect: "none",
+                  },
+                  "& .MuiAutocomplete-clearIndicator": {
+                    display: "none",
+                  },
                 },
-                "& .MuiAutocomplete-clearIndicator": {
-                  display: "none",
-                },
-              },
-              // The field is a display for the selected value, never typeable —
-              // search happens in the popup's SearchInput, not here. The
-              // component-level `readOnly`/`disabled` props are handled by the
-              // Autocomplete above.
-              readOnly: true,
-            }}
-          />
-        )}
+                // The field is a display for the selected value, never typeable —
+                // search happens in the popup's SearchInput, not here. The
+                // component-level `readOnly`/`disabled` props are handled by the
+                // Autocomplete above.
+                readOnly: true,
+              }}
+            />
+          );
+        }}
         renderOption={(propsOption, option) => {
           const { key, ...optionProps } = propsOption;
           return (


### PR DESCRIPTION
## What & why

`SelectInput` already forwarded `startAdornment` but silently dropped `endAdornment`. This adds `endAdornment` support so consumers can render a trailing element — e.g. the **"Matched"** status chip on a vendor select — just before the dropdown arrow.

| Before | After |
|--------|-------|
| `endAdornment` ignored | `endAdornment` renders in a right-anchored row, immediately left of the arrow |

## Implementation notes

MUI's `Autocomplete` renders the dropdown arrow (and clear icon) inside its **own absolutely-positioned wrapper**, so naively adding an `endAdornment` would overlap the arrow. Instead we:

- Unwrap MUI's indicator children (`React.isValidElement` guard — no `any`) and lay them out together with the custom `endAdornment` in a single right-anchored flex row.
- Preserve the arrow's open/close toggle + rotation behaviour and the hidden clear indicator.
- Keep the input a non-typeable display (unchanged).

## Docs

- New live **"With End Adornment"** example reproducing the vendor "Matched" chip.
- `endAdornment` added to the props table.

## Verification

- `tsc --noEmit` ✅  ·  `eslint` ✅
- Verified in the docs site (DOM): value shown, chip present and positioned **left of the arrow**, both vertically centered, arrow still interactive.

## Notes

- Non-breaking — additive prop; existing usages unaffected.
- Library change: bumps `package.json` `2.4.1` → `2.4.2` so it can be published to consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)