### PR TITLE
ci: dedupe publish runs and restrict CI to pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: Publish Package
 on:
   release:
     types: [created]
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes three GitHub Actions trigger problems. Confirmed against run history (each release produced a duplicate failing `Publish Package` run; `CI` fired on every master push).

## Changes

### 1. Publish Package — no longer runs twice
`publish.yml` triggered on **both** `release: created` **and** `push: tags: v*`. Creating a GitHub release also creates the tag, so both fired for one release — the second (tag) run then **failed** on `npm publish` because the version was already published by the first (release) run.

```diff
 on:
   release:
     types: [created]
-  push:
-    tags:
-      - 'v*'
```

Now publishing runs **once, on release**. (The release-triggered run is the one that was already succeeding.)

### 2. CI — runs only on pull requests
`ci.yml` triggered on `push` to master/develop **and** `pull_request`, so it re-ran on every merge to master, duplicating the PR validation.

```diff
 on:
-  push:
-    branches: [main, master, develop]
   pull_request:
     branches: [main, master, develop]
```

### 3. Deploy Documentation — unchanged
`docs.yml` already runs on `push` to `master` (for `docs/**` / `src/**` changes). No change needed — included here for completeness.

## Net effect
- **Open/update a PR** → CI (lint + build).
- **Merge to master** → Deploy Documentation.
- **Publish a release** → Publish Package (once).

## Note
Kept `release: types: [created]` (the event that was already publishing successfully) rather than switching to `published`, to avoid changing publish behavior beyond removing the duplicate. Happy to switch to `[published]` if you prefer drafts not to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)