### PR TITLE
feat: add data-id prop for automation testing across components

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,65 @@ import { HEIGHTS, FontSizeMap, ButtonBorderRadiusMap, Colors } from '@flipspaces
 // Colors: Common color tokens
 ```
 
+## Test IDs (`data-id`)
+
+Every input control accepts a `data-id` prop and renders it as a `data-id` DOM
+attribute — a stable hook for end-to-end tests and analytics.
+
+```tsx
+<TextInput data-id="vendor-name" label="Vendor name" />
+<SelectInput data-id="vendor-status" options={statusOptions} value={status} />
+<NumberStepper data-id="qty" value={qty} onChange={setQty} />
+```
+
+A given `data-id` lands on **exactly one** element, so `[data-id="x"]` never
+matches twice. Controls with a single focusable input put it on that `<input>`
+(`TextInput`, `TextArea`, `SearchInput`, `SelectInput`, `AutoComplete`,
+`DateInput`, `Checkbox`, `RadioButton`, `Switch`, `PinCommentInput`). Composite
+controls put it on their root and stamp suffixed ids on the interactive
+children:
+
+| Component | Child ids |
+|---|---|
+| `NumberStepper` | `{id}-decrement`, `{id}-value`, `{id}-increment` |
+| `SegmentedToggle` | `{id}-{option.value}` per segment |
+| `PinInput` | `{id}-0` … `{id}-{length-1}` per digit cell |
+| `SelectInput` | `{id}-option-{value}`, `{id}-search` |
+| `AutoComplete` | `{id}-option-{index}` |
+| `SearchInput` | `{id}-clear` |
+| `PinCommentInput` | `{id}-send` |
+| `FileUpload` | `{id}-input` (hidden file input), `{id}-remove` |
+| `MonthYearPicker` | `{id}-mode-{month\|quarter\|year}`, `{id}-period-{key}` |
+
+```ts
+await page.fill('[data-id="vendor-name"]', 'Saigon Interiors')
+await page.click('[data-id="qty-increment"]')
+await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')
+```
+
+Note that TypeScript does **not** type-check hyphenated JSX attributes, so a
+`data-id` passed to a component that ignores it compiles cleanly and renders
+nothing. The prop is therefore declared explicitly via the exported
+`DataIdProps` type — import it when composing your own wrappers:
+
+```tsx
+import { TextInput, type DataIdProps } from '@flipspacesit/fs-ui';
+
+interface VendorFieldProps extends DataIdProps {
+  label: string;
+}
+
+const VendorField = ({ label, 'data-id': dataId }: VendorFieldProps) => (
+  <TextInput label={label} data-id={dataId} />
+);
+```
+
+This is unrelated to `data-testid` — `Dropdown`, `SplitMenu`, `Dialog` and
+`ModalLayout` still expose their own `testid` props.
+
+See the **Test IDs (data-id)** page in the docs site for the full per-component
+table.
+
 ## Icons
 
 ```tsx

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -14,6 +14,7 @@ import CommandPalette from "./shell/CommandPalette";
 import GettingStarted from "./pages/GettingStarted";
 import InstallationDocs from "./pages/InstallationDocs";
 import ApiReferenceDocs from "./pages/ApiReferenceDocs";
+import TestIdsDocs from "./pages/TestIdsDocs";
 import ThemeDocs from "./pages/ThemeDocs";
 import TypographyDocs from "./pages/TypographyDocs";
 import SpacingDocs from "./pages/SpacingDocs";
@@ -70,6 +71,7 @@ const pageComponents: Record<
   "getting-started": GettingStarted,
   installation: InstallationDocs,
   "api-reference": ApiReferenceDocs,
+  "test-ids": TestIdsDocs,
   theme: ThemeDocs,
   typography: TypographyDocs,
   spacing: SpacingDocs,

--- a/docs/src/pages/AutoCompleteDocs.tsx
+++ b/docs/src/pages/AutoCompleteDocs.tsx
@@ -275,6 +275,12 @@ const colorsMap = {
               default: "-",
               description: "Color mapping for options",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the `<input>`; suggestion rows get `{id}-option-{index}`. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/ButtonExtrasDocs.tsx
+++ b/docs/src/pages/ButtonExtrasDocs.tsx
@@ -165,6 +165,12 @@ const [off, setOff] = useState(false);
               description:
                 "All other MUI Switch props (checked, onChange, disabled, …) are supported",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the underlying checkbox `<input>`, not the track/thumb span. See Test IDs.",
+            },
           ]}
         />
       </DocSection>
@@ -238,6 +244,12 @@ const [off, setOff] = useState(false);
               type: "SxProps<Theme>",
               default: "{}",
               description: "MUI `sx` overrides, merged last.",
+            },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the root; each segment gets `{id}-{option.value}`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/CalendarDocs.tsx
+++ b/docs/src/pages/CalendarDocs.tsx
@@ -123,6 +123,12 @@ const CalendarDocs: React.FC = () => {
               default: "{}",
               description: "MUI `sx` overrides, merged last.",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the calendar root. See Test IDs.",
+            },
           ]}
         />
       </DocSection>
@@ -218,6 +224,12 @@ const CalendarDocs: React.FC = () => {
               type: "SxProps<Theme>",
               default: "{}",
               description: "MUI `sx` overrides, merged last.",
+            },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the root, plus `{id}-mode-{month|quarter|year}` and `{id}-period-{key}`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/ControlsDocs.tsx
+++ b/docs/src/pages/ControlsDocs.tsx
@@ -99,6 +99,12 @@ const ControlsDocs: React.FC = () => {
               description:
                 "All MUI Checkbox props are supported (except color, which is remapped to the DS family)",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the underlying checkbox `<input>`, not the indicator span. See Test IDs.",
+            },
           ]}
         />
       </DocSection>
@@ -135,6 +141,12 @@ const ControlsDocs: React.FC = () => {
               type: `Omit<RadioProps, "color">`,
               description:
                 "All MUI Radio props are supported (except color, which is remapped to the DS family)",
+            },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the underlying radio `<input>`, not the indicator span. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/DateInputDocs.tsx
+++ b/docs/src/pages/DateInputDocs.tsx
@@ -173,6 +173,12 @@ const [date, setDate] = useState<Dayjs | null>(null);
               type: "SxProps<Theme>",
               description: "Custom styles for the DatePicker TextField",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the field `<input>`. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/DropdownExtrasDocs.tsx
+++ b/docs/src/pages/DropdownExtrasDocs.tsx
@@ -110,6 +110,12 @@ const DropdownExtrasDocs: React.FC = () => {
               type: "SxProps<Theme>",
               description: "MUI sx overrides, merged last.",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the clickable trigger root. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/FileUploadDocs.tsx
+++ b/docs/src/pages/FileUploadDocs.tsx
@@ -300,6 +300,12 @@ function MyForm() {
               type: "SxProps<Theme>",
               description: "Custom styles for the upload icon container on the right side",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the wrapper, `{id}-input` on the hidden file input (use this with setInputFiles), `{id}-remove` on the remove button. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/InputExtrasDocs.tsx
+++ b/docs/src/pages/InputExtrasDocs.tsx
@@ -81,6 +81,12 @@ const InputExtrasDocs: React.FC = () => {
               description:
                 "All MUI TextField props except multiline (always on) are supported.",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — rendered as `data-id` on the `<textarea>` element. See Test IDs.",
+            },
           ]}
         />
       </DocSection>
@@ -143,6 +149,12 @@ const InputExtrasDocs: React.FC = () => {
               name: "sx",
               type: "SxProps<Theme>",
               description: "MUI sx overrides, merged last.",
+            },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the root; each digit cell gets `{id}-{index}` (0-based). See Test IDs.",
             },
           ]}
         />
@@ -216,6 +228,12 @@ const InputExtrasDocs: React.FC = () => {
               name: "sx",
               type: "SxProps<Theme>",
               description: "MUI sx overrides, merged last.",
+            },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the root, plus `{id}-decrement`, `{id}-value` and `{id}-increment`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/PinsDocs.tsx
+++ b/docs/src/pages/PinsDocs.tsx
@@ -270,6 +270,12 @@ const PinsDocs: React.FC = () => {
               type: "SxProps<Theme>",
               description: "MUI `sx` overrides, merged last.",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the `<input>`; the send button gets `{id}-send`. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/SearchInputDocs.tsx
+++ b/docs/src/pages/SearchInputDocs.tsx
@@ -160,6 +160,12 @@ function MyComponent() {
               type: "TextFieldProps",
               description: "All MUI TextField props are supported",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the `<input>`; the clear button gets `{id}-clear`. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/SelectInputDocs.tsx
+++ b/docs/src/pages/SelectInputDocs.tsx
@@ -326,6 +326,12 @@ const [status, setStatus] = useState('');
               type: "SelectProps",
               description: "All MUI Select props are supported",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — `data-id` on the trigger `<input>`; option rows get `{id}-option-{value}`, the in-menu search box `{id}-search`. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/pages/TestIdsDocs.tsx
+++ b/docs/src/pages/TestIdsDocs.tsx
@@ -1,0 +1,294 @@
+import React, { useState } from "react";
+import { Box, Typography, Stack } from "@mui/material";
+import { DocSection, ExampleBox } from "../components/DocSection";
+import CodeBlock from "../components/CodeBlock";
+import { t } from "../docTokens";
+import { SelectInput, TextInput, NumberStepper } from "../../../src";
+
+/** One row of the component → target-element mapping table. */
+interface TargetRow {
+  component: string;
+  /** Where the bare `data-id` value lands. */
+  target: string;
+  /** Suffixed ids stamped on interactive children, if any. */
+  children?: string;
+}
+
+const TARGETS: TargetRow[] = [
+  { component: "TextInput", target: "<input>" },
+  { component: "TextArea", target: "<textarea>" },
+  {
+    component: "SearchInput",
+    target: "<input>",
+    children: "{id}-clear (clear button)",
+  },
+  {
+    component: "SelectInput",
+    target: "<input> (the trigger)",
+    children: "{id}-option-{value}, {id}-search",
+  },
+  {
+    component: "AutoComplete",
+    target: "<input>",
+    children: "{id}-option-{index}",
+  },
+  { component: "DateInput", target: "<input> (the field)" },
+  { component: "Checkbox", target: '<input type="checkbox">' },
+  { component: "RadioButton", target: '<input type="radio">' },
+  { component: "Switch", target: '<input type="checkbox">' },
+  {
+    component: "PinCommentInput",
+    target: "<input>",
+    children: "{id}-send (send button)",
+  },
+  {
+    component: "PinInput",
+    target: "root",
+    children: "{id}-0 … {id}-{length-1} (digit cells)",
+  },
+  {
+    component: "NumberStepper",
+    target: "root",
+    children: "{id}-decrement, {id}-value, {id}-increment",
+  },
+  {
+    component: "SegmentedToggle",
+    target: "root",
+    children: "{id}-{option.value} (each segment)",
+  },
+  {
+    component: "MonthYearPicker",
+    target: "root",
+    children: "{id}-mode-{month|quarter|year}, {id}-period-{key}",
+  },
+  { component: "DateRangePicker", target: "root (calendar paper)" },
+  {
+    component: "FileUpload",
+    target: "root",
+    children: "{id}-input (hidden file input), {id}-remove",
+  },
+  { component: "CountryDropdown", target: "root (the trigger)" },
+  { component: "Dropdown", target: "root (the trigger)" },
+];
+
+/** Monospace inline code, matching the PropsTable pill treatment. */
+const Mono: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Box
+    component="code"
+    className="doc-mono"
+    sx={{
+      fontSize: 12,
+      backgroundColor: t.sunken,
+      border: `1px solid ${t.border}`,
+      borderRadius: "6px",
+      px: "6px",
+      py: "2px",
+      color: t.accent,
+      whiteSpace: "nowrap",
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const TestIdsDocs: React.FC = () => {
+  const [status, setStatus] = useState("");
+  const [qty, setQty] = useState(1);
+
+  return (
+    <Box>
+      <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
+        Test IDs (<Box component="span" className="doc-mono">data-id</Box>)
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+        Every fs-ui input control accepts a <code>data-id</code> prop and renders
+        it as a <code>data-id</code> DOM attribute — a stable hook for end-to-end
+        tests and analytics that does not depend on class names, labels, or
+        markup structure.
+      </Typography>
+
+      <DocSection title="Usage">
+        <ExampleBox>
+          <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+            <TextInput data-id="vendor-name" label="Vendor name" />
+            <SelectInput
+              data-id="vendor-status"
+              label="Status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value as string)}
+              options={[
+                { label: "Active", value: "active" },
+                { label: "Inactive", value: "inactive" },
+              ]}
+              placeholder="Select status"
+            />
+            <NumberStepper data-id="qty" value={qty} onChange={setQty} />
+            <Typography variant="caption" color="text.secondary">
+              Inspect the elements above — each carries its <code>data-id</code>.
+            </Typography>
+          </Stack>
+        </ExampleBox>
+        <CodeBlock
+          code={`<TextInput data-id="vendor-name" label="Vendor name" />
+
+<SelectInput
+  data-id="vendor-status"
+  label="Status"
+  value={status}
+  onChange={(e) => setStatus(e.target.value)}
+  options={statusOptions}
+/>
+
+<NumberStepper data-id="qty" value={qty} onChange={setQty} />`}
+        />
+      </DocSection>
+
+      <DocSection
+        title="One element per value"
+        description="A given data-id is rendered on exactly one element, so a [data-id='x'] selector never matches twice."
+      >
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Controls that own a single focusable input put the value on that{" "}
+          <code>&lt;input&gt;</code> — so you can type into it, assert its value,
+          or check it directly. Composite controls (segments, PIN cells, stepper
+          buttons) put the bare value on their root and stamp{" "}
+          <strong>suffixed</strong> ids on the interactive children, because a
+          root-only attribute would give you nothing to click.
+        </Typography>
+        <CodeBlock
+          code={`// Single-input control → the value is ON the input
+await page.fill('[data-id="vendor-name"]', 'Saigon Interiors')
+
+// Composite control → root carries the bare id, children carry suffixes
+await page.click('[data-id="qty-increment"]')
+await expect(page.locator('[data-id="qty-value"]')).toHaveText('2')
+
+// SelectInput: open the trigger, then pick an option by its value
+await page.click('[data-id="vendor-status"]')
+await page.click('[data-id="vendor-status-option-active"]')
+
+// FileUpload: target the hidden input, not the dropzone
+await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')`}
+        />
+      </DocSection>
+
+      <DocSection
+        title="Where the attribute lands"
+        description="Per-component target element and the suffixed ids each one emits."
+      >
+        <Box
+          sx={{
+            border: `1px solid ${t.border}`,
+            borderRadius: "10px",
+            overflow: "hidden",
+          }}
+        >
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1.1fr 1.2fr 2fr",
+              gap: 0,
+              backgroundColor: t.sunken,
+              px: 2,
+              py: 1.25,
+              borderBottom: `1px solid ${t.border}`,
+            }}
+          >
+            {["Component", "data-id lands on", "Child ids"].map((h) => (
+              <Typography
+                key={h}
+                variant="caption"
+                sx={{ fontWeight: 700, color: t.textMuted }}
+              >
+                {h}
+              </Typography>
+            ))}
+          </Box>
+          {TARGETS.map((row, i) => (
+            <Box
+              key={row.component}
+              sx={{
+                display: "grid",
+                gridTemplateColumns: "1.1fr 1.2fr 2fr",
+                alignItems: "center",
+                gap: 1,
+                px: 2,
+                py: 1.25,
+                borderBottom:
+                  i === TARGETS.length - 1 ? "none" : `1px solid ${t.border}`,
+              }}
+            >
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {row.component}
+              </Typography>
+              <Box>
+                <Mono>{row.target}</Mono>
+              </Box>
+              <Typography variant="caption" color="text.secondary">
+                {row.children ?? "—"}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </DocSection>
+
+      <DocSection
+        title="Why an explicit prop"
+        description="A wrong data-id fails silently, so the prop is declared rather than left to rest-prop spreading."
+      >
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          TypeScript does not type-check hyphenated JSX attributes. A{" "}
+          <code>data-id</code> passed to a component that ignores it compiles
+          cleanly and renders nothing — there is no error to catch it. Declaring{" "}
+          <code>data-id</code> on the props type means the library controls where
+          it lands, and the docs can tell you which element that is.
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Import <code>DataIdProps</code> when composing your own wrappers so
+          the prop flows through:
+        </Typography>
+        <CodeBlock
+          code={`import { TextInput, type DataIdProps } from '@flipspacesit/fs-ui'
+
+interface VendorFieldProps extends DataIdProps {
+  label: string
+}
+
+const VendorField = ({ label, 'data-id': dataId }: VendorFieldProps) => (
+  <TextInput label={label} data-id={dataId} />
+)`}
+        />
+      </DocSection>
+
+      <DocSection title="Notes">
+        <Stack spacing={1.5}>
+          <Typography variant="body2" color="text.secondary">
+            • Omitting <code>data-id</code> renders no attribute at all — there
+            is no default value and no markup cost.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            • Your own <code>inputProps</code> / <code>slotProps</code> are
+            merged, not replaced: passing{" "}
+            <code>inputProps={`{{ maxLength: 5 }}`}</code> alongside{" "}
+            <code>data-id</code> keeps both.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            • Suffixed child ids are derived from your value, so keep ids
+            URL-safe and stable. For <code>SelectInput</code> and{" "}
+            <code>SegmentedToggle</code> the suffix is the option{" "}
+            <code>value</code> (not the label), so it survives copy changes and
+            translation.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            • <code>data-testid</code> is unrelated and untouched —{" "}
+            <code>Dropdown</code>, <code>SplitMenu</code>, <code>Dialog</code>{" "}
+            and <code>ModalLayout</code> still expose their own{" "}
+            <code>testid</code> props.
+          </Typography>
+        </Stack>
+      </DocSection>
+    </Box>
+  );
+};
+
+export default TestIdsDocs;

--- a/docs/src/pages/TextInputDocs.tsx
+++ b/docs/src/pages/TextInputDocs.tsx
@@ -204,6 +204,12 @@ const TextInputDocs: React.FC = () => {
               type: "TextFieldProps",
               description: "All MUI TextField props are supported",
             },
+            {
+              name: "data-id",
+              type: "string",
+              description:
+                "Automation hook — rendered as `data-id` on the `<input>` element. See Test IDs.",
+            },
           ]}
         />
       </DocSection>

--- a/docs/src/shell/CommandPalette.tsx
+++ b/docs/src/shell/CommandPalette.tsx
@@ -76,7 +76,12 @@ const Highlighted: React.FC<{ text: string; q: string }> = ({ text, q }) => {
   );
 };
 
-export const CommandPalette: React.FC<Props> = ({ open, onClose, onSelect }) => {
+export const CommandPalette: React.FC<Props> = ({
+  open,
+  onClose,
+  onSelect,
+  onSelectIcon,
+}) => {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const [prevOpen, setPrevOpen] = useState(open);

--- a/docs/src/shell/nav.ts
+++ b/docs/src/shell/nav.ts
@@ -17,6 +17,7 @@ export const menuItems: MenuItem[] = [
   { id: "getting-started", label: "Getting Started", category: "Introduction" },
   { id: "installation", label: "Installation", category: "Introduction" },
   { id: "api-reference", label: "API Reference", category: "Introduction" },
+  { id: "test-ids", label: "Test IDs (data-id)", category: "Introduction" },
   { id: "theme", label: "Theme (Colors)", category: "Foundation" },
   { id: "typography", label: "Typography", category: "Foundation" },
   { id: "spacing", label: "Spacing & Grid", category: "Foundation" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipspacesit/fs-ui",
-  "version": "2.4.7",
+  "version": "2.5.0",
   "description": "Flipspaces shared UI component library",
   "type": "module",
   "main": "./dist/fs-ui.cjs.js",

--- a/src/components/AutoComplete/index.tsx
+++ b/src/components/AutoComplete/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Popper, Tooltip } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import type { DataIdProps } from "../../constants";
 
 const AutoCompleteContainer = styled("div")({
   position: "relative",
@@ -60,7 +61,11 @@ const DropdownItem = styled("li")<{
   },
 }));
 
-export interface AutoCompleteProps {
+/**
+ * Props for {@link AutoComplete}. `data-id` lands on the `<input>`; suggestion
+ * rows get `{data-id}-option-{index}`.
+ */
+export interface AutoCompleteProps extends DataIdProps {
   /** Current value */
   value?: string;
   /** Callback when input changes */
@@ -106,6 +111,7 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
   dropDownItemStyles = {},
   colorsMap,
   placeholder = "Select",
+  "data-id": dataId,
 }) => {
   const [inputValue, setInputValue] = useState(value);
   const [prevValue, setPrevValue] = useState(value);
@@ -172,6 +178,7 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
         <StyledInput
           ref={inputRef}
           type="text"
+          data-id={dataId}
           value={inputValue}
           onChange={(e) => {
             const newValue = e.target.value;
@@ -249,6 +256,7 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
           {displayedOptions.map((option, index) => (
             <DropdownItem
               key={`${option}-${index}`}
+              data-id={dataId ? `${dataId}-option-${index}` : undefined}
               selected={option === value}
               isLongText={option.length > 40}
               itemColor={colorsMap?.[option]?.[0]}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -7,6 +7,7 @@ import {
   Box,
 } from "@mui/material";
 import { primary, neutral } from "../../theme/tokens/colors";
+import { withDataIdSlot, type DataIdProps } from "../../constants";
 
 /** DS colour family for the Checkbox / RadioButton indicator. */
 export type CheckColor =
@@ -75,8 +76,14 @@ const boxBase = {
   boxSizing: "border-box" as const,
 };
 
-/** Props for {@link Checkbox}; extends MUI `CheckboxProps` (minus `color`, which is remapped to the DS family). */
-export interface FsCheckboxProps extends Omit<CheckboxProps, "color"> {
+/**
+ * Props for {@link Checkbox}; extends MUI `CheckboxProps` (minus `color`, which
+ * is remapped to the DS family). `data-id` lands on the underlying
+ * `<input type="checkbox">`, not the styled indicator span.
+ */
+export interface FsCheckboxProps
+  extends Omit<CheckboxProps, "color">,
+    DataIdProps {
   /** DS colour family */
   color?: CheckColor;
   /** Hard (opaque fill) or Soft (pale-tinted fill) */
@@ -90,6 +97,7 @@ export interface FsCheckboxProps extends Omit<CheckboxProps, "color"> {
 export const Checkbox: React.FC<FsCheckboxProps> = ({
   color = "slateBlue",
   variant = "hard",
+  "data-id": dataId,
   ...props
 }) => {
   const h = HUES[color];
@@ -123,12 +131,23 @@ export const Checkbox: React.FC<FsCheckboxProps> = ({
         </Box>
       }
       {...props}
+      slotProps={{
+        ...props.slotProps,
+        input: withDataIdSlot(
+          props.slotProps?.input ?? props.inputProps,
+          dataId,
+        ),
+      }}
     />
   );
 };
 
-/** Props for {@link RadioButton}; extends MUI `RadioProps` (minus `color`, which is remapped to the DS family). */
-export interface FsRadioProps extends Omit<RadioProps, "color"> {
+/**
+ * Props for {@link RadioButton}; extends MUI `RadioProps` (minus `color`, which
+ * is remapped to the DS family). `data-id` lands on the underlying
+ * `<input type="radio">`, not the styled indicator span.
+ */
+export interface FsRadioProps extends Omit<RadioProps, "color">, DataIdProps {
   /** DS colour family */
   color?: CheckColor;
 }
@@ -142,6 +161,7 @@ const circleBase = { ...boxBase, borderRadius: "50%" };
  */
 export const RadioButton: React.FC<FsRadioProps> = ({
   color = "slateBlue",
+  "data-id": dataId,
   ...props
 }) => {
   const h = HUES[color];
@@ -162,6 +182,13 @@ export const RadioButton: React.FC<FsRadioProps> = ({
         </Box>
       }
       {...props}
+      slotProps={{
+        ...props.slotProps,
+        input: withDataIdSlot(
+          props.slotProps?.input ?? props.inputProps,
+          dataId,
+        ),
+      }}
     />
   );
 };

--- a/src/components/CountryDropdown/index.tsx
+++ b/src/components/CountryDropdown/index.tsx
@@ -5,13 +5,17 @@ import {
   FontSizeMap,
   ComponentSize,
   ComponentVariant,
+  type DataIdProps,
 } from "../../constants";
 import { theme } from "../../theme";
 import { ArrowDown } from "../../icons/ArrowDown";
 import { ArrowUp } from "../../icons/ArrowUp";
 
-/** Props for {@link CountryDropdown}. */
-export interface CountryDropdownProps {
+/**
+ * Props for {@link CountryDropdown}. `data-id` lands on the clickable trigger
+ * root (this component renders no `<input>` — it is a trigger only).
+ */
+export interface CountryDropdownProps extends DataIdProps {
   /** Flag element (img / emoji) shown in the leading badge */
   flag?: React.ReactNode;
   /** Label, e.g. "+91" or "India" */
@@ -43,6 +47,7 @@ export const CountryDropdown: React.FC<CountryDropdownProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
+  "data-id": dataId,
 }) => {
   // Size-driven height scaled by the consumer-set `--scale` CSS variable.
   const height = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -56,6 +61,7 @@ export const CountryDropdown: React.FC<CountryDropdownProps> = ({
       alignItems="center"
       gap="8px"
       onClick={disabled ? undefined : onClick}
+      data-id={dataId}
       sx={{
         height,
         pl: "1px",

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -12,6 +12,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import type { Dayjs } from 'dayjs'
 import theme from '@/theme'
+import type { DataIdProps } from '../../constants'
 import {
   buttons,
   fontFamily,
@@ -24,22 +25,28 @@ import {
 } from '@/theme/tokens'
 import { CalendarBlank } from '@/icons'
 
-export type DateInputProps = DatePickerProps & {
-  label?: string
-  value: Dayjs | null
-  onChange: (value: Dayjs | null) => void
-  error?: boolean
-  helperText?: string
-  required?: boolean
-  fullWidth?: boolean
-  sx?: SxProps<Theme>
-  format?: string
-  placeholder?: string
-  // Style customization props
-  labelSx?: SxProps<Theme>
-  helperTextSx?: SxProps<Theme>
-  datePickerSx?: SxProps<Theme>
-}
+/**
+ * Props for {@link DateInput}. `data-id` lands on the field `<input>`.
+ * Needed as an explicit prop because this component supplies its own
+ * `slotProps`, which shadows any `slotProps.textField` a consumer passes.
+ */
+export type DateInputProps = DatePickerProps &
+  DataIdProps & {
+    label?: string
+    value: Dayjs | null
+    onChange: (value: Dayjs | null) => void
+    error?: boolean
+    helperText?: string
+    required?: boolean
+    fullWidth?: boolean
+    sx?: SxProps<Theme>
+    format?: string
+    placeholder?: string
+    // Style customization props
+    labelSx?: SxProps<Theme>
+    helperTextSx?: SxProps<Theme>
+    datePickerSx?: SxProps<Theme>
+  }
 
 const StyledFormLabel = styled(FormLabel)(() => ({
   fontFamily,
@@ -177,6 +184,7 @@ export const DateInput = ({
   labelSx,
   helperTextSx,
   datePickerSx,
+  'data-id': dataId,
   ...props
 }: DateInputProps) => {
   return (
@@ -208,6 +216,7 @@ export const DateInput = ({
                 inputProps: {
                   placeholder: placeholder || format,
                   readOnly: true,
+                  'data-id': dataId,
                 },
               },
               field: {

--- a/src/components/DateRangePicker/index.tsx
+++ b/src/components/DateRangePicker/index.tsx
@@ -8,6 +8,7 @@ import type { Dayjs } from "dayjs";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
 import { primary } from "../../theme/tokens/colors";
+import type { DataIdProps } from "../../constants";
 
 /** A selected date range; either endpoint may be `null` while picking. */
 export interface DateRange {
@@ -17,8 +18,12 @@ export interface DateRange {
   end: Dayjs | null;
 }
 
-/** Props for {@link DateRangePicker}. */
-export interface DateRangePickerProps {
+/**
+ * Props for {@link DateRangePicker}. `data-id` lands on the calendar root
+ * (day cells are MUI-owned; target them via the root, e.g.
+ * `[data-id="x"] button[aria-label*="15"]`).
+ */
+export interface DateRangePickerProps extends DataIdProps {
   /** Selected range */
   value: DateRange;
   /** Change callback */
@@ -36,6 +41,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   value,
   onChange,
   sx = {},
+  "data-id": dataId,
 }) => {
   const { start, end } = value;
 
@@ -87,6 +93,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Paper
         elevation={0}
+        data-id={dataId}
         sx={{
           display: "inline-block",
           border: `0.5px solid ${theme.palette.primaryBlue[500]}`,

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -19,6 +19,7 @@ import {
   CloseIcon,
 } from "@/icons";
 import theme from "@/theme";
+import type { DataIdProps } from "../../constants";
 
 export interface FileUploadResponse {
   documentUrl: string;
@@ -28,7 +29,13 @@ export interface FileUploadResponse {
   documentSize: number;
 }
 
-export interface FileUploadBoxProps {
+/**
+ * Props for {@link FileUpload}. `data-id` lands on the outer wrapper (the
+ * dropzone and the uploaded-file card swap places inside it); the hidden file
+ * input gets `{data-id}-input` — the one to use with Playwright's
+ * `setInputFiles` — and the remove button `{data-id}-remove`.
+ */
+export interface FileUploadBoxProps extends DataIdProps {
   required?: boolean;
   error?: boolean;
   helperText?: string;
@@ -312,6 +319,7 @@ export const FileUpload = ({
   fileNameSx,
   uploadContentSx,
   uploadIconContainerSx,
+  "data-id": dataId,
 }: FileUploadBoxProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -450,7 +458,7 @@ export const FileUpload = ({
   };
 
   return (
-    <Stack width='100%'>
+    <Stack width='100%' data-id={dataId}>
       {!displayFile ? (
         <>
           <Stack position='relative'>
@@ -492,6 +500,7 @@ export const FileUpload = ({
 
               <FileInputHidden
                 ref={fileInputRef}
+                data-id={dataId ? `${dataId}-input` : undefined}
                 type='file'
                 accept={accept}
                 onChange={handleFileInputChange}
@@ -526,7 +535,10 @@ export const FileUpload = ({
                 {displayFile?.name}
               </FileNameTypography>
             </FileContentStack>
-            <RemoveIconStack onClick={handleRemoveFile}>
+            <RemoveIconStack
+              onClick={handleRemoveFile}
+              data-id={dataId ? `${dataId}-remove` : undefined}
+            >
               <CloseIcon size='12' />
             </RemoveIconStack>
           </FileContainer>

--- a/src/components/MonthYearPicker/index.tsx
+++ b/src/components/MonthYearPicker/index.tsx
@@ -2,12 +2,17 @@ import React, { useState } from "react";
 import { Paper, Stack, Box, Typography, SxProps, Theme } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
+import type { DataIdProps } from "../../constants";
 
 /** Selection granularity tab: month grid, quarter grid, or fiscal-year grid. */
 export type MonthYearMode = "month" | "quarter" | "year";
 
-/** Props for {@link MonthYearPicker}. */
-export interface MonthYearPickerProps {
+/**
+ * Props for {@link MonthYearPicker}. `data-id` lands on the root; the mode tabs
+ * get `{data-id}-mode-{month|quarter|year}` and each period cell
+ * `{data-id}-period-{key}`.
+ */
+export interface MonthYearPickerProps extends DataIdProps {
   /** Which tab is shown initially */
   defaultMode?: MonthYearMode;
   /** Selected period key (e.g. "Jan 2024", "Q1 2024", "2024-25") */
@@ -41,6 +46,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
   year = new Date().getFullYear(),
   yearRange = 6,
   sx = {},
+  "data-id": dataId,
 }) => {
   const [mode, setMode] = useState<MonthYearMode>(defaultMode);
 
@@ -59,6 +65,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
   return (
     <Paper
       elevation={0}
+      data-id={dataId}
       sx={{
         display: "inline-block",
         width: 280,
@@ -82,6 +89,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
           <Box
             key={m}
             onClick={() => setMode(m)}
+            data-id={dataId ? `${dataId}-mode-${m}` : undefined}
             sx={{ flex: 1, textAlign: "center", py: "4px", cursor: "pointer" }}
           >
             <Typography
@@ -114,6 +122,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
             <Box
               key={p}
               onClick={() => onChange(p)}
+              data-id={dataId ? `${dataId}-period-${p}` : undefined}
               sx={{
                 py: "6px",
                 textAlign: "center",

--- a/src/components/NumberStepper/index.tsx
+++ b/src/components/NumberStepper/index.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { Stack, Box, Typography, SxProps, Theme } from "@mui/material";
-import { HEIGHTS, ComponentSize } from "../../constants";
+import { HEIGHTS, ComponentSize, type DataIdProps } from "../../constants";
 import { theme } from "../../theme";
 
-/** Props for {@link NumberStepper}. */
-export interface NumberStepperProps {
+/**
+ * Props for {@link NumberStepper}. `data-id` lands on the root; the controls get
+ * `{data-id}-decrement`, `{data-id}-value` and `{data-id}-increment`.
+ */
+export interface NumberStepperProps extends DataIdProps {
   /** Current value */
   value: number;
   /** Change callback */
@@ -36,6 +39,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
+  "data-id": dataId,
 }) => {
   // Square button/value cell edge: size-driven height scaled by the app's `--scale` CSS var.
   const dim = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -62,6 +66,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
     <Stack
       direction="row"
       alignItems="center"
+      data-id={dataId}
       sx={{
         opacity: disabled ? 0.6 : 1,
         borderRadius: "4px",
@@ -76,6 +81,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         role="button"
         tabIndex={disabled ? -1 : 0}
         aria-label="Decrease"
+        data-id={dataId ? `${dataId}-decrement` : undefined}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -87,6 +93,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         −
       </Box>
       <Box
+        data-id={dataId ? `${dataId}-value` : undefined}
         sx={{
           minWidth: dim,
           height: dim,
@@ -108,6 +115,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         role="button"
         tabIndex={disabled ? -1 : 0}
         aria-label="Increase"
+        data-id={dataId ? `${dataId}-increment` : undefined}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();

--- a/src/components/PinCommentInput/index.tsx
+++ b/src/components/PinCommentInput/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Stack, Box, styled, SxProps, Theme } from "@mui/material";
 import { neutral, primary } from "../../theme/tokens/colors";
 import { theme } from "../../theme";
+import type { DataIdProps } from "../../constants";
 
 // Borderless transparent text input filling the pill; italic grey placeholder.
 const Field = styled("input")({
@@ -15,8 +16,11 @@ const Field = styled("input")({
   "&::placeholder": { fontStyle: "italic", color: theme.palette.grey[300] },
 });
 
-/** Props for {@link PinCommentInput}. */
-export interface PinCommentInputProps {
+/**
+ * Props for {@link PinCommentInput}. `data-id` lands on the `<input>`; the send
+ * button gets `{data-id}-send`.
+ */
+export interface PinCommentInputProps extends DataIdProps {
   /** Current comment text (controlled). */
   value: string;
   /** Fired with the new text on every keystroke. */
@@ -39,6 +43,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
   onSend,
   placeholder = "Add a Comment",
   sx = {},
+  "data-id": dataId,
 }) => {
   const hasText = value.trim().length > 0;
   return (
@@ -56,6 +61,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
       }}
     >
       <Field
+        data-id={dataId}
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
@@ -65,6 +71,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
       />
       <Box
         onClick={() => hasText && onSend?.()}
+        data-id={dataId ? `${dataId}-send` : undefined}
         sx={{
           width: 28,
           height: 28,

--- a/src/components/PinInput/index.tsx
+++ b/src/components/PinInput/index.tsx
@@ -1,11 +1,14 @@
 import React, { useRef } from "react";
 import { Stack, Box, styled, SxProps, Theme } from "@mui/material";
-import { HEIGHTS, ComponentSize } from "../../constants";
+import { HEIGHTS, ComponentSize, type DataIdProps } from "../../constants";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
 
-/** Props for the {@link PinInput} OTP / PIN entry component. */
-export interface PinInputProps {
+/**
+ * Props for the {@link PinInput} OTP / PIN entry component. `data-id` lands on
+ * the root; each digit cell gets `{data-id}-{index}` (0-based).
+ */
+export interface PinInputProps extends DataIdProps {
   /** Number of cells */
   length?: number;
   /** Current value */
@@ -56,6 +59,7 @@ export const PinInput: React.FC<PinInputProps> = ({
   size = "large",
   disabled = false,
   sx = {},
+  "data-id": dataId,
 }) => {
   const refs = useRef<Array<HTMLInputElement | null>>([]);
   const dim = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -79,7 +83,13 @@ export const PinInput: React.FC<PinInputProps> = ({
   };
 
   return (
-    <Stack direction="row" alignItems="center" gap="8px" sx={sx}>
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap="8px"
+      sx={sx}
+      data-id={dataId}
+    >
       {Array.from({ length }).map((_, i) => (
         <React.Fragment key={i}>
           {splitAfter && i === splitAfter && (
@@ -95,6 +105,7 @@ export const PinInput: React.FC<PinInputProps> = ({
             ref={(el: HTMLInputElement | null) => {
               refs.current[i] = el;
             }}
+            data-id={dataId ? `${dataId}-${i}` : undefined}
             inputMode="numeric"
             maxLength={1}
             disabled={disabled}

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
+import { withDataId, type DataIdProps } from "../../constants";
 
 /** Internal magnifier (leading) icon; `size` px and `color` default to the DS grey-400. */
 // Magnifier (leading) icon
@@ -56,9 +57,14 @@ const ClearIcon: React.FC<{ size?: number; color?: string }> = ({
   </svg>
 );
 
-/** Props for {@link SearchInput}; extends MUI `TextFieldProps` (minus its own `onChange`/`value`). */
+/**
+ * Props for {@link SearchInput}; extends MUI `TextFieldProps` (minus its own
+ * `onChange`/`value`). `data-id` lands on the `<input>`; the clear button gets
+ * `{data-id}-clear`.
+ */
 export interface SearchInputProps
-  extends Omit<TextFieldProps, "onChange" | "value"> {
+  extends Omit<TextFieldProps, "onChange" | "value">,
+    DataIdProps {
   /** Current search value */
   value?: string;
   /** Callback when search value changes */
@@ -102,6 +108,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   size = "small",
   containerSx = {},
   onClear,
+  "data-id": dataId,
   ...rest
 }) => {
   const [internalValue, setInternalValue] = useState(controlledValue ?? "");
@@ -175,6 +182,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
                 onClick={handleClear}
                 edge="end"
                 aria-label="clear search"
+                data-id={dataId ? `${dataId}-clear` : undefined}
                 disableRipple
               >
                 <ClearIcon size={iconPx} />
@@ -197,6 +205,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         ...containerSx,
       }}
       {...rest}
+      inputProps={withDataId(rest.inputProps, dataId)}
     />
   );
 };

--- a/src/components/SegmentedToggle/index.tsx
+++ b/src/components/SegmentedToggle/index.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { Stack, Typography, SxProps, Theme } from "@mui/material";
-import { HEIGHTS, FontSizeMap, ComponentSize } from "../../constants";
+import {
+  HEIGHTS,
+  FontSizeMap,
+  ComponentSize,
+  type DataIdProps,
+} from "../../constants";
 import { theme } from "../../theme";
 
 /** One selectable segment of a {@link SegmentedToggle}. */
@@ -13,8 +18,11 @@ export interface SegmentedToggleOption {
   icon?: React.ReactNode;
 }
 
-/** Props for {@link SegmentedToggle}. */
-export interface SegmentedToggleProps {
+/**
+ * Props for {@link SegmentedToggle}. `data-id` lands on the root; each segment
+ * gets `{data-id}-{option.value}`.
+ */
+export interface SegmentedToggleProps extends DataIdProps {
   /** Segments */
   options: SegmentedToggleOption[];
   /** Currently selected value */
@@ -41,6 +49,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
+  "data-id": dataId,
 }) => {
   // Scale the button-matched height by the app-provided `--scale` CSS var.
   const height = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -50,6 +59,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
     <Stack
       direction="row"
       alignItems="center"
+      data-id={dataId}
       sx={{
         height,
         p: "2px",
@@ -73,6 +83,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
             justifyContent="center"
             gap="6px"
             onClick={() => onChange(opt.value)}
+            data-id={dataId ? `${dataId}-${opt.value}` : undefined}
             sx={{
               height: "100%",
               px: "12px",

--- a/src/components/SelectInput/index.tsx
+++ b/src/components/SelectInput/index.tsx
@@ -18,6 +18,7 @@ import {
 import { styled } from "@mui/material/styles";
 import theme from "@/theme";
 import { ArrowDown2, CheckIcon } from "@/icons";
+import { withDataId, type DataIdProps } from "../../constants";
 import SearchInput from "../SearchInput";
 
 export type Option = {
@@ -26,26 +27,33 @@ export type Option = {
   icon?: React.ReactNode;
 };
 
+/**
+ * Props for {@link SelectInput}.
+ *
+ * `data-id` lands on the trigger `<input>`; option rows get
+ * `{data-id}-option-{value}` and the in-menu search box `{data-id}-search`.
+ */
 export type SelectInputProps<T = unknown> = Omit<
   SelectProps<T>,
   "renderValue"
-> & {
-  label?: string;
-  helperText?: React.ReactNode;
-  options?: Option[];
-  placeholder?: string;
-  showSelectedIcon?: boolean;
-  searchable?: boolean;
-  searchPlaceholder?: string;
-  // Style customization props
-  labelSx?: SxProps<Theme>;
-  helperTextSx?: SxProps<Theme>;
-  menuPaperSx?: SxProps<Theme>;
-  menuItemStackSx?: SxProps<Theme>;
-  menuItemTypographySx?: SxProps<Theme>;
-  inputSx?: SxProps<Theme>;
-  menuItemSx?: SxProps<Theme>;
-};
+> &
+  DataIdProps & {
+    label?: string;
+    helperText?: React.ReactNode;
+    options?: Option[];
+    placeholder?: string;
+    showSelectedIcon?: boolean;
+    searchable?: boolean;
+    searchPlaceholder?: string;
+    // Style customization props
+    labelSx?: SxProps<Theme>;
+    helperTextSx?: SxProps<Theme>;
+    menuPaperSx?: SxProps<Theme>;
+    menuItemStackSx?: SxProps<Theme>;
+    menuItemTypographySx?: SxProps<Theme>;
+    inputSx?: SxProps<Theme>;
+    menuItemSx?: SxProps<Theme>;
+  };
 
 const StyledFormLabel = styled(FormLabel)(() => ({
   fontSize: "12px",
@@ -91,6 +99,7 @@ export const SelectInput = <T = unknown,>({
   menuItemSx,
   disabled = false,
   readOnly = false,
+  "data-id": dataId,
   ...props
 }: SelectInputProps<T>) => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -189,6 +198,9 @@ export const SelectInput = <T = unknown,>({
               placeholder={!selectedOption ? placeholder : undefined}
               required={required}
               error={props.error}
+              // Merge, don't replace: `params.inputProps` carries the
+              // Autocomplete's combobox a11y wiring and change handlers.
+              inputProps={withDataId(params.inputProps, dataId)}
               InputProps={{
                 ...params.InputProps,
                 startAdornment: startAdornment ? (
@@ -244,6 +256,7 @@ export const SelectInput = <T = unknown,>({
             <MenuItem
               key={key}
               {...optionProps}
+              data-id={dataId ? `${dataId}-option-${option.value}` : undefined}
               sx={{
                 height: "calc(28px * var(--scale))",
                 minHeight: "auto",
@@ -318,6 +331,7 @@ export const SelectInput = <T = unknown,>({
               <Box ref={searchRef} sx={{ marginBottom: "4px" }}>
                 <SearchInput
                   autoFocus
+                  data-id={dataId ? `${dataId}-search` : undefined}
                   inputRef={searchInputRef}
                   size='small'
                   value={searchTerm}

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -8,9 +8,14 @@ import {
 } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
+import { withDataIdSlot, type DataIdProps } from "../../constants";
 
-/** Props for {@link Switch}; extends MUI `SwitchProps` (minus `color`) with an optional label. */
-export interface FsSwitchProps extends Omit<SwitchProps, "color"> {
+/**
+ * Props for {@link Switch}; extends MUI `SwitchProps` (minus `color`) with an
+ * optional label. `data-id` lands on the underlying `<input type="checkbox">`,
+ * not the styled track/thumb span.
+ */
+export interface FsSwitchProps extends Omit<SwitchProps, "color">, DataIdProps {
   /** Optional label rendered beside the switch */
   label?: React.ReactNode;
   /** Wrapper styles when a label is present */
@@ -25,6 +30,7 @@ export const Switch: React.FC<FsSwitchProps> = ({
   label,
   wrapperSx,
   sx,
+  "data-id": dataId,
   ...props
 }) => {
   const control = (
@@ -49,6 +55,15 @@ export const Switch: React.FC<FsSwitchProps> = ({
         ...sx,
       }}
       {...props}
+      // MUI's Switch ignores the deprecated `inputProps` bag entirely, and
+      // overwrites its own `slotProps.input` default rather than merging —
+      // so `role="switch"` has to be re-supplied here or it is lost.
+      slotProps={{
+        ...props.slotProps,
+        input: withDataIdSlot(props.slotProps?.input, dataId, {
+          role: "switch",
+        }),
+      }}
     />
   );
 

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { TextField, TextFieldProps, SxProps, Theme } from "@mui/material";
 import { theme } from "../../theme";
+import { withDataId, type DataIdProps } from "../../constants";
 
-/** Props for {@link TextArea}; all MUI `TextField` props except `multiline` (always on), plus row bounds. */
-export interface TextAreaProps extends Omit<TextFieldProps, "multiline"> {
+/**
+ * Props for {@link TextArea}; all MUI `TextField` props except `multiline`
+ * (always on), plus row bounds. `data-id` lands on the `<textarea>` element.
+ */
+export interface TextAreaProps
+  extends Omit<TextFieldProps, "multiline">,
+    DataIdProps {
   /** Minimum number of visible text rows before the field grows. Defaults to 4. */
   minRows?: number;
   /** Maximum number of visible text rows; beyond this the field scrolls. Unbounded if omitted. */
@@ -20,6 +26,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   minRows = 4,
   maxRows,
   sx = {},
+  "data-id": dataId,
   ...props
 }) => {
   return (
@@ -42,6 +49,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
         ...sx,
       }}
       {...props}
+      inputProps={withDataId(props.inputProps, dataId)}
     />
   );
 };

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -11,16 +11,19 @@ import {
   Theme,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
+import { withDataId, type DataIdProps } from "../../constants";
 
-export type TextInputProps = TextFieldProps & {
-  label?: string;
-  startAdornment?: React.ReactNode;
-  endAdornment?: React.ReactNode;
-  readOnly?: boolean;
-  labelSx?: SxProps<Theme>;
-  inputSx?: SxProps<Theme>;
-  helperTextSx?: SxProps<Theme>;
-};
+/** Props for {@link TextInput}. `data-id` lands on the `<input>` element. */
+export type TextInputProps = TextFieldProps &
+  DataIdProps & {
+    label?: string;
+    startAdornment?: React.ReactNode;
+    endAdornment?: React.ReactNode;
+    readOnly?: boolean;
+    labelSx?: SxProps<Theme>;
+    inputSx?: SxProps<Theme>;
+    helperTextSx?: SxProps<Theme>;
+  };
 
 const StyledFormLabel = styled(FormLabel)(() => ({
   fontSize: "12px",
@@ -55,6 +58,7 @@ export const TextInput = ({
   inputSx,
   helperTextSx,
   sx,
+  "data-id": dataId,
   ...props
 }: TextInputProps) => {
   return (
@@ -71,6 +75,7 @@ export const TextInput = ({
           error={error}
           {...props}
           sx={inputSx}
+          inputProps={withDataId(props.inputProps, dataId)}
           InputProps={{
             readOnly,
             ...props.InputProps,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,59 @@ export type ComponentSize =
 /** Shape variant shared by buttons/controls — `round` = pill, `rectangular` = radius-sm. */
 export type ComponentVariant = "round" | "rectangular";
 
+/**
+ * Opt-in automation hook shared by every fs-ui input control.
+ *
+ * Each control renders the value on exactly one element — the focusable
+ * `<input>` when it owns a single one, otherwise its root — so a
+ * `[data-id="x"]` selector never matches twice. Composite controls (segments,
+ * PIN cells, stepper buttons, option rows) additionally stamp suffixed ids
+ * (`x-increment`, `x-option-2`, …) on their interactive children; each
+ * component's TSDoc lists the suffixes it emits.
+ *
+ * Declared explicitly because most of these components have closed prop
+ * interfaces that drop unknown props. TypeScript also skips type-checking
+ * hyphenated JSX attributes, so an unsupported `data-id` fails silently —
+ * hence the explicit prop rather than relying on rest-prop spreading.
+ */
+export interface DataIdProps {
+  /** Rendered as the `data-id` DOM attribute for test/analytics targeting. */
+  "data-id"?: string;
+}
+
+/**
+ * Merges a `data-id` into a component's `inputProps` bag, preserving whatever
+ * the caller already put there.
+ *
+ * The assertion is load-bearing: MUI types some `inputProps` slots as
+ * `InputHTMLAttributes<HTMLInputElement>` (Checkbox, Radio, Switch), and an
+ * object literal with a hyphenated key trips excess-property checking there.
+ * JSX attributes are exempt from that check; object literals are not.
+ */
+export const withDataId = <T,>(inputProps: T | undefined, dataId?: string): T =>
+  ({ ...inputProps, "data-id": dataId }) as T;
+
+/**
+ * Same as {@link withDataId}, for MUI's `slotProps.input` channel — which
+ * accepts either an object or an `ownerState` callback, so both forms have to
+ * survive the merge.
+ *
+ * Used by the SwitchBase family (Checkbox / RadioButton / Switch), where the
+ * legacy `inputProps` bag is deprecated and, on `Switch`, ignored outright.
+ * `base` carries defaults that MUI itself sets on the slot and would otherwise
+ * lose — passing `slotProps.input` to `Switch` replaces its `role="switch"`
+ * wholesale rather than merging into it.
+ */
+export const withDataIdSlot = <S extends object, O>(
+  slot: S | ((ownerState: O) => S) | undefined,
+  dataId: string | undefined,
+  base?: object,
+): S | ((ownerState: O) => S) =>
+  typeof slot === "function"
+    ? (ownerState: O) =>
+        ({ ...base, ...slot(ownerState), "data-id": dataId }) as S
+    : ({ ...base, ...slot, "data-id": dataId }) as S;
+
 /** Control heights per {@link ComponentSize} (px, before `--scale`). */
 export const HEIGHTS: Record<ComponentSize, string> = {
   extraSmall: "20px",

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,7 @@ export {
   Colors,
   type ComponentSize,
   type ComponentVariant,
+  type DataIdProps,
 } from './constants'
 
 // Icons


### PR DESCRIPTION
- Introduced a `data-id` prop to various components (TextInput, AutoComplete, Checkbox, etc.) to facilitate automation testing.
- Updated documentation to reflect the new `data-id` prop usage.
- Enhanced the `withDataId` and `withDataIdSlot` utility functions for merging `data-id` into input properties.
- Bumped version to 2.5.0 to include these changes.