### PR TITLE
refactor: replace `data-id` with `data-testid` across components and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,18 +270,18 @@ import { HEIGHTS, FontSizeMap, ButtonBorderRadiusMap, Colors } from '@flipspaces
 // Colors: Common color tokens
 ```
 
-## Test IDs (`data-id`)
+## Test IDs (`data-testid`)
 
-Every input control accepts a `data-id` prop and renders it as a `data-id` DOM
+Every input control accepts a `data-testid` prop and renders it as a `data-testid` DOM
 attribute — a stable hook for end-to-end tests and analytics.
 
 ```tsx
-<TextInput data-id="vendor-name" label="Vendor name" />
-<SelectInput data-id="vendor-status" options={statusOptions} value={status} />
-<NumberStepper data-id="qty" value={qty} onChange={setQty} />
+<TextInput data-testid="vendor-name" label="Vendor name" />
+<SelectInput data-testid="vendor-status" options={statusOptions} value={status} />
+<NumberStepper data-testid="qty" value={qty} onChange={setQty} />
 ```
 
-A given `data-id` lands on **exactly one** element, so `[data-id="x"]` never
+A given `data-testid` lands on **exactly one** element, so `[data-testid="x"]` never
 matches twice. Controls with a single focusable input put it on that `<input>`
 (`TextInput`, `TextArea`, `SearchInput`, `SelectInput`, `AutoComplete`,
 `DateInput`, `Checkbox`, `RadioButton`, `Switch`, `PinCommentInput`). Composite
@@ -301,32 +301,32 @@ children:
 | `MonthYearPicker` | `{id}-mode-{month\|quarter\|year}`, `{id}-period-{key}` |
 
 ```ts
-await page.fill('[data-id="vendor-name"]', 'Saigon Interiors')
-await page.click('[data-id="qty-increment"]')
-await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')
+await page.fill('[data-testid="vendor-name"]', 'Saigon Interiors')
+await page.click('[data-testid="qty-increment"]')
+await page.setInputFiles('[data-testid="invoice-doc-input"]', 'invoice.pdf')
 ```
 
 Note that TypeScript does **not** type-check hyphenated JSX attributes, so a
-`data-id` passed to a component that ignores it compiles cleanly and renders
+`data-testid` passed to a component that ignores it compiles cleanly and renders
 nothing. The prop is therefore declared explicitly via the exported
-`DataIdProps` type — import it when composing your own wrappers:
+`DataTestIdProps` type — import it when composing your own wrappers:
 
 ```tsx
-import { TextInput, type DataIdProps } from '@flipspacesit/fs-ui';
+import { TextInput, type DataTestIdProps } from '@flipspacesit/fs-ui';
 
-interface VendorFieldProps extends DataIdProps {
+interface VendorFieldProps extends DataTestIdProps {
   label: string;
 }
 
-const VendorField = ({ label, 'data-id': dataId }: VendorFieldProps) => (
-  <TextInput label={label} data-id={dataId} />
+const VendorField = ({ label, 'data-testid': dataTestId }: VendorFieldProps) => (
+  <TextInput label={label} data-testid={dataTestId} />
 );
 ```
 
 This is unrelated to `data-testid` — `Dropdown`, `SplitMenu`, `Dialog` and
 `ModalLayout` still expose their own `testid` props.
 
-See the **Test IDs (data-id)** page in the docs site for the full per-component
+See the **Test IDs (data-testid)** page in the docs site for the full per-component
 table.
 
 ## Icons

--- a/docs/src/pages/AutoCompleteDocs.tsx
+++ b/docs/src/pages/AutoCompleteDocs.tsx
@@ -276,10 +276,10 @@ const colorsMap = {
               description: "Color mapping for options",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the `<input>`; suggestion rows get `{id}-option-{index}`. See Test IDs.",
+                "Automation hook — `data-testid` on the `<input>`; suggestion rows get `{id}-option-{index}`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/ButtonExtrasDocs.tsx
+++ b/docs/src/pages/ButtonExtrasDocs.tsx
@@ -166,10 +166,10 @@ const [off, setOff] = useState(false);
                 "All other MUI Switch props (checked, onChange, disabled, …) are supported",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the underlying checkbox `<input>`, not the track/thumb span. See Test IDs.",
+                "Automation hook — `data-testid` on the underlying checkbox `<input>`, not the track/thumb span. See Test IDs.",
             },
           ]}
         />
@@ -246,10 +246,10 @@ const [off, setOff] = useState(false);
               description: "MUI `sx` overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the root; each segment gets `{id}-{option.value}`. See Test IDs.",
+                "Automation hook — `data-testid` on the root; each segment gets `{id}-{option.value}`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/CalendarDocs.tsx
+++ b/docs/src/pages/CalendarDocs.tsx
@@ -124,10 +124,10 @@ const CalendarDocs: React.FC = () => {
               description: "MUI `sx` overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the calendar root. See Test IDs.",
+                "Automation hook — `data-testid` on the calendar root. See Test IDs.",
             },
           ]}
         />
@@ -226,10 +226,10 @@ const CalendarDocs: React.FC = () => {
               description: "MUI `sx` overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the root, plus `{id}-mode-{month|quarter|year}` and `{id}-period-{key}`. See Test IDs.",
+                "Automation hook — `data-testid` on the root, plus `{id}-mode-{month|quarter|year}` and `{id}-period-{key}`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/ControlsDocs.tsx
+++ b/docs/src/pages/ControlsDocs.tsx
@@ -100,10 +100,10 @@ const ControlsDocs: React.FC = () => {
                 "All MUI Checkbox props are supported (except color, which is remapped to the DS family)",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the underlying checkbox `<input>`, not the indicator span. See Test IDs.",
+                "Automation hook — `data-testid` on the underlying checkbox `<input>`, not the indicator span. See Test IDs.",
             },
           ]}
         />
@@ -143,10 +143,10 @@ const ControlsDocs: React.FC = () => {
                 "All MUI Radio props are supported (except color, which is remapped to the DS family)",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the underlying radio `<input>`, not the indicator span. See Test IDs.",
+                "Automation hook — `data-testid` on the underlying radio `<input>`, not the indicator span. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/DateInputDocs.tsx
+++ b/docs/src/pages/DateInputDocs.tsx
@@ -174,10 +174,10 @@ const [date, setDate] = useState<Dayjs | null>(null);
               description: "Custom styles for the DatePicker TextField",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the field `<input>`. See Test IDs.",
+                "Automation hook — `data-testid` on the field `<input>`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/DropdownExtrasDocs.tsx
+++ b/docs/src/pages/DropdownExtrasDocs.tsx
@@ -111,10 +111,10 @@ const DropdownExtrasDocs: React.FC = () => {
               description: "MUI sx overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the clickable trigger root. See Test IDs.",
+                "Automation hook — `data-testid` on the clickable trigger root. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/FileUploadDocs.tsx
+++ b/docs/src/pages/FileUploadDocs.tsx
@@ -301,10 +301,10 @@ function MyForm() {
               description: "Custom styles for the upload icon container on the right side",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the wrapper, `{id}-input` on the hidden file input (use this with setInputFiles), `{id}-remove` on the remove button. See Test IDs.",
+                "Automation hook — `data-testid` on the wrapper, `{id}-input` on the hidden file input (use this with setInputFiles), `{id}-remove` on the remove button. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/InputExtrasDocs.tsx
+++ b/docs/src/pages/InputExtrasDocs.tsx
@@ -82,10 +82,10 @@ const InputExtrasDocs: React.FC = () => {
                 "All MUI TextField props except multiline (always on) are supported.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — rendered as `data-id` on the `<textarea>` element. See Test IDs.",
+                "Automation hook — rendered as `data-testid` on the `<textarea>` element. See Test IDs.",
             },
           ]}
         />
@@ -151,10 +151,10 @@ const InputExtrasDocs: React.FC = () => {
               description: "MUI sx overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the root; each digit cell gets `{id}-{index}` (0-based). See Test IDs.",
+                "Automation hook — `data-testid` on the root; each digit cell gets `{id}-{index}` (0-based). See Test IDs.",
             },
           ]}
         />
@@ -230,10 +230,10 @@ const InputExtrasDocs: React.FC = () => {
               description: "MUI sx overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the root, plus `{id}-decrement`, `{id}-value` and `{id}-increment`. See Test IDs.",
+                "Automation hook — `data-testid` on the root, plus `{id}-decrement`, `{id}-value` and `{id}-increment`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/PinsDocs.tsx
+++ b/docs/src/pages/PinsDocs.tsx
@@ -271,10 +271,10 @@ const PinsDocs: React.FC = () => {
               description: "MUI `sx` overrides, merged last.",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the `<input>`; the send button gets `{id}-send`. See Test IDs.",
+                "Automation hook — `data-testid` on the `<input>`; the send button gets `{id}-send`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/SearchInputDocs.tsx
+++ b/docs/src/pages/SearchInputDocs.tsx
@@ -161,10 +161,10 @@ function MyComponent() {
               description: "All MUI TextField props are supported",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the `<input>`; the clear button gets `{id}-clear`. See Test IDs.",
+                "Automation hook — `data-testid` on the `<input>`; the clear button gets `{id}-clear`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/SelectInputDocs.tsx
+++ b/docs/src/pages/SelectInputDocs.tsx
@@ -327,10 +327,10 @@ const [status, setStatus] = useState('');
               description: "All MUI Select props are supported",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — `data-id` on the trigger `<input>`; option rows get `{id}-option-{value}`, the in-menu search box `{id}-search`. See Test IDs.",
+                "Automation hook — `data-testid` on the trigger `<input>`; option rows get `{id}-option-{value}`, the in-menu search box `{id}-search`. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/pages/TestIdsDocs.tsx
+++ b/docs/src/pages/TestIdsDocs.tsx
@@ -8,7 +8,7 @@ import { SelectInput, TextInput, NumberStepper } from "../../../src";
 /** One row of the component → target-element mapping table. */
 interface TargetRow {
   component: string;
-  /** Where the bare `data-id` value lands. */
+  /** Where the bare `data-testid` value lands. */
   target: string;
   /** Suffixed ids stamped on interactive children, if any. */
   children?: string;
@@ -98,21 +98,21 @@ const TestIdsDocs: React.FC = () => {
   return (
     <Box>
       <Typography variant="h4" sx={{ fontWeight: 700, mb: 2 }}>
-        Test IDs (<Box component="span" className="doc-mono">data-id</Box>)
+        Test IDs (<Box component="span" className="doc-mono">data-testid</Box>)
       </Typography>
       <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
-        Every fs-ui input control accepts a <code>data-id</code> prop and renders
-        it as a <code>data-id</code> DOM attribute — a stable hook for end-to-end
-        tests and analytics that does not depend on class names, labels, or
-        markup structure.
+        Every fs-ui input control accepts a <code>data-testid</code> prop and
+        renders it as a <code>data-testid</code> DOM attribute — a stable hook
+        for end-to-end tests and analytics that does not depend on class names,
+        labels, or markup structure.
       </Typography>
 
       <DocSection title="Usage">
         <ExampleBox>
           <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
-            <TextInput data-id="vendor-name" label="Vendor name" />
+            <TextInput data-testid="vendor-name" label="Vendor name" />
             <SelectInput
-              data-id="vendor-status"
+              data-testid="vendor-status"
               label="Status"
               value={status}
               onChange={(e) => setStatus(e.target.value as string)}
@@ -122,30 +122,31 @@ const TestIdsDocs: React.FC = () => {
               ]}
               placeholder="Select status"
             />
-            <NumberStepper data-id="qty" value={qty} onChange={setQty} />
+            <NumberStepper data-testid="qty" value={qty} onChange={setQty} />
             <Typography variant="caption" color="text.secondary">
-              Inspect the elements above — each carries its <code>data-id</code>.
+              Inspect the elements above — each carries its{" "}
+              <code>data-testid</code>.
             </Typography>
           </Stack>
         </ExampleBox>
         <CodeBlock
-          code={`<TextInput data-id="vendor-name" label="Vendor name" />
+          code={`<TextInput data-testid="vendor-name" label="Vendor name" />
 
 <SelectInput
-  data-id="vendor-status"
+  data-testid="vendor-status"
   label="Status"
   value={status}
   onChange={(e) => setStatus(e.target.value)}
   options={statusOptions}
 />
 
-<NumberStepper data-id="qty" value={qty} onChange={setQty} />`}
+<NumberStepper data-testid="qty" value={qty} onChange={setQty} />`}
         />
       </DocSection>
 
       <DocSection
         title="One element per value"
-        description="A given data-id is rendered on exactly one element, so a [data-id='x'] selector never matches twice."
+        description="A given data-testid is rendered on exactly one element, so a [data-testid='x'] selector never matches twice."
       >
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           Controls that own a single focusable input put the value on that{" "}
@@ -157,18 +158,18 @@ const TestIdsDocs: React.FC = () => {
         </Typography>
         <CodeBlock
           code={`// Single-input control → the value is ON the input
-await page.fill('[data-id="vendor-name"]', 'Saigon Interiors')
+await page.fill('[data-testid="vendor-name"]', 'Saigon Interiors')
 
 // Composite control → root carries the bare id, children carry suffixes
-await page.click('[data-id="qty-increment"]')
-await expect(page.locator('[data-id="qty-value"]')).toHaveText('2')
+await page.click('[data-testid="qty-increment"]')
+await expect(page.locator('[data-testid="qty-value"]')).toHaveText('2')
 
 // SelectInput: open the trigger, then pick an option by its value
-await page.click('[data-id="vendor-status"]')
-await page.click('[data-id="vendor-status-option-active"]')
+await page.click('[data-testid="vendor-status"]')
+await page.click('[data-testid="vendor-status-option-active"]')
 
 // FileUpload: target the hidden input, not the dropzone
-await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')`}
+await page.setInputFiles('[data-testid="invoice-doc-input"]', 'invoice.pdf')`}
         />
       </DocSection>
 
@@ -194,7 +195,7 @@ await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')`}
               borderBottom: `1px solid ${t.border}`,
             }}
           >
-            {["Component", "data-id lands on", "Child ids"].map((h) => (
+            {["Component", "data-testid lands on", "Child ids"].map((h) => (
               <Typography
                 key={h}
                 variant="caption"
@@ -234,28 +235,32 @@ await page.setInputFiles('[data-id="invoice-doc-input"]', 'invoice.pdf')`}
 
       <DocSection
         title="Why an explicit prop"
-        description="A wrong data-id fails silently, so the prop is declared rather than left to rest-prop spreading."
+        description="A wrong data-testid fails silently, so the prop is declared rather than left to rest-prop spreading."
       >
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           TypeScript does not type-check hyphenated JSX attributes. A{" "}
-          <code>data-id</code> passed to a component that ignores it compiles
-          cleanly and renders nothing — there is no error to catch it. Declaring{" "}
-          <code>data-id</code> on the props type means the library controls where
-          it lands, and the docs can tell you which element that is.
+          <code>data-testid</code> passed to a component that ignores it
+          compiles cleanly and renders nothing — there is no error to catch it.
+          Declaring <code>data-testid</code> on the props type means the library
+          controls where it lands, and the docs can tell you which element that
+          is.
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Import <code>DataIdProps</code> when composing your own wrappers so
-          the prop flows through:
+          Import <code>DataTestIdProps</code> when composing your own wrappers
+          so the prop flows through:
         </Typography>
         <CodeBlock
-          code={`import { TextInput, type DataIdProps } from '@flipspacesit/fs-ui'
+          code={`import { TextInput, type DataTestIdProps } from '@flipspacesit/fs-ui'
 
-interface VendorFieldProps extends DataIdProps {
+interface VendorFieldProps extends DataTestIdProps {
   label: string
 }
 
-const VendorField = ({ label, 'data-id': dataId }: VendorFieldProps) => (
-  <TextInput label={label} data-id={dataId} />
+const VendorField = ({
+  label,
+  'data-testid': dataTestId,
+}: VendorFieldProps) => (
+  <TextInput label={label} data-testid={dataTestId} />
 )`}
         />
       </DocSection>
@@ -263,14 +268,14 @@ const VendorField = ({ label, 'data-id': dataId }: VendorFieldProps) => (
       <DocSection title="Notes">
         <Stack spacing={1.5}>
           <Typography variant="body2" color="text.secondary">
-            • Omitting <code>data-id</code> renders no attribute at all — there
-            is no default value and no markup cost.
+            • Omitting <code>data-testid</code> renders no attribute at
+            all — there is no default value and no markup cost.
           </Typography>
           <Typography variant="body2" color="text.secondary">
             • Your own <code>inputProps</code> / <code>slotProps</code> are
             merged, not replaced: passing{" "}
             <code>inputProps={`{{ maxLength: 5 }}`}</code> alongside{" "}
-            <code>data-id</code> keeps both.
+            <code>data-testid</code> keeps both.
           </Typography>
           <Typography variant="body2" color="text.secondary">
             • Suffixed child ids are derived from your value, so keep ids

--- a/docs/src/pages/TextInputDocs.tsx
+++ b/docs/src/pages/TextInputDocs.tsx
@@ -205,10 +205,10 @@ const TextInputDocs: React.FC = () => {
               description: "All MUI TextField props are supported",
             },
             {
-              name: "data-id",
+              name: "data-testid",
               type: "string",
               description:
-                "Automation hook — rendered as `data-id` on the `<input>` element. See Test IDs.",
+                "Automation hook — rendered as `data-testid` on the `<input>` element. See Test IDs.",
             },
           ]}
         />

--- a/docs/src/shell/nav.ts
+++ b/docs/src/shell/nav.ts
@@ -17,7 +17,7 @@ export const menuItems: MenuItem[] = [
   { id: "getting-started", label: "Getting Started", category: "Introduction" },
   { id: "installation", label: "Installation", category: "Introduction" },
   { id: "api-reference", label: "API Reference", category: "Introduction" },
-  { id: "test-ids", label: "Test IDs (data-id)", category: "Introduction" },
+  { id: "test-ids", label: "Test IDs (data-testid)", category: "Introduction" },
   { id: "theme", label: "Theme (Colors)", category: "Foundation" },
   { id: "typography", label: "Typography", category: "Foundation" },
   { id: "spacing", label: "Spacing & Grid", category: "Foundation" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flipspacesit/fs-ui",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Flipspaces shared UI component library",
   "type": "module",
   "main": "./dist/fs-ui.cjs.js",

--- a/src/components/AutoComplete/index.tsx
+++ b/src/components/AutoComplete/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { Popper, Tooltip } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import type { DataIdProps } from "../../constants";
+import type { DataTestIdProps } from "../../constants";
 
 const AutoCompleteContainer = styled("div")({
   position: "relative",
@@ -62,10 +62,10 @@ const DropdownItem = styled("li")<{
 }));
 
 /**
- * Props for {@link AutoComplete}. `data-id` lands on the `<input>`; suggestion
- * rows get `{data-id}-option-{index}`.
+ * Props for {@link AutoComplete}. `data-testid` lands on the `<input>`;
+ * suggestion rows get `{data-testid}-option-{index}`.
  */
-export interface AutoCompleteProps extends DataIdProps {
+export interface AutoCompleteProps extends DataTestIdProps {
   /** Current value */
   value?: string;
   /** Callback when input changes */
@@ -111,7 +111,7 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
   dropDownItemStyles = {},
   colorsMap,
   placeholder = "Select",
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   const [inputValue, setInputValue] = useState(value);
   const [prevValue, setPrevValue] = useState(value);
@@ -178,7 +178,7 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
         <StyledInput
           ref={inputRef}
           type="text"
-          data-id={dataId}
+          data-testid={dataTestId}
           value={inputValue}
           onChange={(e) => {
             const newValue = e.target.value;
@@ -256,7 +256,9 @@ export const AutoComplete: React.FC<AutoCompleteProps> = ({
           {displayedOptions.map((option, index) => (
             <DropdownItem
               key={`${option}-${index}`}
-              data-id={dataId ? `${dataId}-option-${index}` : undefined}
+              data-testid={
+                dataTestId ? `${dataTestId}-option-${index}` : undefined
+              }
               selected={option === value}
               isLongText={option.length > 40}
               itemColor={colorsMap?.[option]?.[0]}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -7,7 +7,7 @@ import {
   Box,
 } from "@mui/material";
 import { primary, neutral } from "../../theme/tokens/colors";
-import { withDataIdSlot, type DataIdProps } from "../../constants";
+import { withDataTestIdSlot, type DataTestIdProps } from "../../constants";
 
 /** DS colour family for the Checkbox / RadioButton indicator. */
 export type CheckColor =
@@ -78,12 +78,12 @@ const boxBase = {
 
 /**
  * Props for {@link Checkbox}; extends MUI `CheckboxProps` (minus `color`, which
- * is remapped to the DS family). `data-id` lands on the underlying
+ * is remapped to the DS family). `data-testid` lands on the underlying
  * `<input type="checkbox">`, not the styled indicator span.
  */
 export interface FsCheckboxProps
   extends Omit<CheckboxProps, "color">,
-    DataIdProps {
+    DataTestIdProps {
   /** DS colour family */
   color?: CheckColor;
   /** Hard (opaque fill) or Soft (pale-tinted fill) */
@@ -97,7 +97,7 @@ export interface FsCheckboxProps
 export const Checkbox: React.FC<FsCheckboxProps> = ({
   color = "slateBlue",
   variant = "hard",
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }) => {
   const h = HUES[color];
@@ -133,9 +133,9 @@ export const Checkbox: React.FC<FsCheckboxProps> = ({
       {...props}
       slotProps={{
         ...props.slotProps,
-        input: withDataIdSlot(
+        input: withDataTestIdSlot(
           props.slotProps?.input ?? props.inputProps,
-          dataId,
+          dataTestId,
         ),
       }}
     />
@@ -144,10 +144,12 @@ export const Checkbox: React.FC<FsCheckboxProps> = ({
 
 /**
  * Props for {@link RadioButton}; extends MUI `RadioProps` (minus `color`, which
- * is remapped to the DS family). `data-id` lands on the underlying
+ * is remapped to the DS family). `data-testid` lands on the underlying
  * `<input type="radio">`, not the styled indicator span.
  */
-export interface FsRadioProps extends Omit<RadioProps, "color">, DataIdProps {
+export interface FsRadioProps
+  extends Omit<RadioProps, "color">,
+    DataTestIdProps {
   /** DS colour family */
   color?: CheckColor;
 }
@@ -161,7 +163,7 @@ const circleBase = { ...boxBase, borderRadius: "50%" };
  */
 export const RadioButton: React.FC<FsRadioProps> = ({
   color = "slateBlue",
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }) => {
   const h = HUES[color];
@@ -184,9 +186,9 @@ export const RadioButton: React.FC<FsRadioProps> = ({
       {...props}
       slotProps={{
         ...props.slotProps,
-        input: withDataIdSlot(
+        input: withDataTestIdSlot(
           props.slotProps?.input ?? props.inputProps,
-          dataId,
+          dataTestId,
         ),
       }}
     />

--- a/src/components/CountryDropdown/index.tsx
+++ b/src/components/CountryDropdown/index.tsx
@@ -5,17 +5,17 @@ import {
   FontSizeMap,
   ComponentSize,
   ComponentVariant,
-  type DataIdProps,
+  type DataTestIdProps,
 } from "../../constants";
 import { theme } from "../../theme";
 import { ArrowDown } from "../../icons/ArrowDown";
 import { ArrowUp } from "../../icons/ArrowUp";
 
 /**
- * Props for {@link CountryDropdown}. `data-id` lands on the clickable trigger
- * root (this component renders no `<input>` — it is a trigger only).
+ * Props for {@link CountryDropdown}. `data-testid` lands on the clickable
+ * trigger root (this component renders no `<input>` — it is a trigger only).
  */
-export interface CountryDropdownProps extends DataIdProps {
+export interface CountryDropdownProps extends DataTestIdProps {
   /** Flag element (img / emoji) shown in the leading badge */
   flag?: React.ReactNode;
   /** Label, e.g. "+91" or "India" */
@@ -47,7 +47,7 @@ export const CountryDropdown: React.FC<CountryDropdownProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   // Size-driven height scaled by the consumer-set `--scale` CSS variable.
   const height = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -61,7 +61,7 @@ export const CountryDropdown: React.FC<CountryDropdownProps> = ({
       alignItems="center"
       gap="8px"
       onClick={disabled ? undefined : onClick}
-      data-id={dataId}
+      data-testid={dataTestId}
       sx={{
         height,
         pl: "1px",

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -12,7 +12,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import type { Dayjs } from 'dayjs'
 import theme from '@/theme'
-import type { DataIdProps } from '../../constants'
+import type { DataTestIdProps } from '../../constants'
 import {
   buttons,
   fontFamily,
@@ -26,12 +26,12 @@ import {
 import { CalendarBlank } from '@/icons'
 
 /**
- * Props for {@link DateInput}. `data-id` lands on the field `<input>`.
+ * Props for {@link DateInput}. `data-testid` lands on the field `<input>`.
  * Needed as an explicit prop because this component supplies its own
  * `slotProps`, which shadows any `slotProps.textField` a consumer passes.
  */
 export type DateInputProps = DatePickerProps &
-  DataIdProps & {
+  DataTestIdProps & {
     label?: string
     value: Dayjs | null
     onChange: (value: Dayjs | null) => void
@@ -184,7 +184,7 @@ export const DateInput = ({
   labelSx,
   helperTextSx,
   datePickerSx,
-  'data-id': dataId,
+  'data-testid': dataTestId,
   ...props
 }: DateInputProps) => {
   return (
@@ -216,7 +216,7 @@ export const DateInput = ({
                 inputProps: {
                   placeholder: placeholder || format,
                   readOnly: true,
-                  'data-id': dataId,
+                  'data-testid': dataTestId,
                 },
               },
               field: {

--- a/src/components/DateRangePicker/index.tsx
+++ b/src/components/DateRangePicker/index.tsx
@@ -8,7 +8,7 @@ import type { Dayjs } from "dayjs";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
 import { primary } from "../../theme/tokens/colors";
-import type { DataIdProps } from "../../constants";
+import type { DataTestIdProps } from "../../constants";
 
 /** A selected date range; either endpoint may be `null` while picking. */
 export interface DateRange {
@@ -19,11 +19,11 @@ export interface DateRange {
 }
 
 /**
- * Props for {@link DateRangePicker}. `data-id` lands on the calendar root
+ * Props for {@link DateRangePicker}. `data-testid` lands on the calendar root
  * (day cells are MUI-owned; target them via the root, e.g.
- * `[data-id="x"] button[aria-label*="15"]`).
+ * `[data-testid="x"] button[aria-label*="15"]`).
  */
-export interface DateRangePickerProps extends DataIdProps {
+export interface DateRangePickerProps extends DataTestIdProps {
   /** Selected range */
   value: DateRange;
   /** Change callback */
@@ -41,7 +41,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   value,
   onChange,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   const { start, end } = value;
 
@@ -93,7 +93,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Paper
         elevation={0}
-        data-id={dataId}
+        data-testid={dataTestId}
         sx={{
           display: "inline-block",
           border: `0.5px solid ${theme.palette.primaryBlue[500]}`,

--- a/src/components/FileUpload/index.tsx
+++ b/src/components/FileUpload/index.tsx
@@ -19,7 +19,7 @@ import {
   CloseIcon,
 } from "@/icons";
 import theme from "@/theme";
-import type { DataIdProps } from "../../constants";
+import type { DataTestIdProps } from "../../constants";
 
 export interface FileUploadResponse {
   documentUrl: string;
@@ -30,12 +30,12 @@ export interface FileUploadResponse {
 }
 
 /**
- * Props for {@link FileUpload}. `data-id` lands on the outer wrapper (the
+ * Props for {@link FileUpload}. `data-testid` lands on the outer wrapper (the
  * dropzone and the uploaded-file card swap places inside it); the hidden file
- * input gets `{data-id}-input` — the one to use with Playwright's
- * `setInputFiles` — and the remove button `{data-id}-remove`.
+ * input gets `{data-testid}-input` — the one to use with Playwright's
+ * `setInputFiles` — and the remove button `{data-testid}-remove`.
  */
-export interface FileUploadBoxProps extends DataIdProps {
+export interface FileUploadBoxProps extends DataTestIdProps {
   required?: boolean;
   error?: boolean;
   helperText?: string;
@@ -319,7 +319,7 @@ export const FileUpload = ({
   fileNameSx,
   uploadContentSx,
   uploadIconContainerSx,
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }: FileUploadBoxProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -458,7 +458,7 @@ export const FileUpload = ({
   };
 
   return (
-    <Stack width='100%' data-id={dataId}>
+    <Stack width='100%' data-testid={dataTestId}>
       {!displayFile ? (
         <>
           <Stack position='relative'>
@@ -500,7 +500,7 @@ export const FileUpload = ({
 
               <FileInputHidden
                 ref={fileInputRef}
-                data-id={dataId ? `${dataId}-input` : undefined}
+                data-testid={dataTestId ? `${dataTestId}-input` : undefined}
                 type='file'
                 accept={accept}
                 onChange={handleFileInputChange}
@@ -537,7 +537,7 @@ export const FileUpload = ({
             </FileContentStack>
             <RemoveIconStack
               onClick={handleRemoveFile}
-              data-id={dataId ? `${dataId}-remove` : undefined}
+              data-testid={dataTestId ? `${dataTestId}-remove` : undefined}
             >
               <CloseIcon size='12' />
             </RemoveIconStack>

--- a/src/components/MonthYearPicker/index.tsx
+++ b/src/components/MonthYearPicker/index.tsx
@@ -2,17 +2,17 @@ import React, { useState } from "react";
 import { Paper, Stack, Box, Typography, SxProps, Theme } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
-import type { DataIdProps } from "../../constants";
+import type { DataTestIdProps } from "../../constants";
 
 /** Selection granularity tab: month grid, quarter grid, or fiscal-year grid. */
 export type MonthYearMode = "month" | "quarter" | "year";
 
 /**
- * Props for {@link MonthYearPicker}. `data-id` lands on the root; the mode tabs
- * get `{data-id}-mode-{month|quarter|year}` and each period cell
- * `{data-id}-period-{key}`.
+ * Props for {@link MonthYearPicker}. `data-testid` lands on the root; the mode
+ * tabs get `{data-testid}-mode-{month|quarter|year}` and each period cell
+ * `{data-testid}-period-{key}`.
  */
-export interface MonthYearPickerProps extends DataIdProps {
+export interface MonthYearPickerProps extends DataTestIdProps {
   /** Which tab is shown initially */
   defaultMode?: MonthYearMode;
   /** Selected period key (e.g. "Jan 2024", "Q1 2024", "2024-25") */
@@ -46,7 +46,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
   year = new Date().getFullYear(),
   yearRange = 6,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   const [mode, setMode] = useState<MonthYearMode>(defaultMode);
 
@@ -65,7 +65,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
   return (
     <Paper
       elevation={0}
-      data-id={dataId}
+      data-testid={dataTestId}
       sx={{
         display: "inline-block",
         width: 280,
@@ -89,7 +89,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
           <Box
             key={m}
             onClick={() => setMode(m)}
-            data-id={dataId ? `${dataId}-mode-${m}` : undefined}
+            data-testid={dataTestId ? `${dataTestId}-mode-${m}` : undefined}
             sx={{ flex: 1, textAlign: "center", py: "4px", cursor: "pointer" }}
           >
             <Typography
@@ -122,7 +122,7 @@ export const MonthYearPicker: React.FC<MonthYearPickerProps> = ({
             <Box
               key={p}
               onClick={() => onChange(p)}
-              data-id={dataId ? `${dataId}-period-${p}` : undefined}
+              data-testid={dataTestId ? `${dataTestId}-period-${p}` : undefined}
               sx={{
                 py: "6px",
                 textAlign: "center",

--- a/src/components/NumberStepper/index.tsx
+++ b/src/components/NumberStepper/index.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { Stack, Box, Typography, SxProps, Theme } from "@mui/material";
-import { HEIGHTS, ComponentSize, type DataIdProps } from "../../constants";
+import { HEIGHTS, ComponentSize, type DataTestIdProps } from "../../constants";
 import { theme } from "../../theme";
 
 /**
- * Props for {@link NumberStepper}. `data-id` lands on the root; the controls get
- * `{data-id}-decrement`, `{data-id}-value` and `{data-id}-increment`.
+ * Props for {@link NumberStepper}. `data-testid` lands on the root; the
+ * controls get `{data-testid}-decrement`, `{data-testid}-value` and
+ * `{data-testid}-increment`.
  */
-export interface NumberStepperProps extends DataIdProps {
+export interface NumberStepperProps extends DataTestIdProps {
   /** Current value */
   value: number;
   /** Change callback */
@@ -39,7 +40,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   // Square button/value cell edge: size-driven height scaled by the app's `--scale` CSS var.
   const dim = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -66,7 +67,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
     <Stack
       direction="row"
       alignItems="center"
-      data-id={dataId}
+      data-testid={dataTestId}
       sx={{
         opacity: disabled ? 0.6 : 1,
         borderRadius: "4px",
@@ -81,7 +82,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         role="button"
         tabIndex={disabled ? -1 : 0}
         aria-label="Decrease"
-        data-id={dataId ? `${dataId}-decrement` : undefined}
+        data-testid={dataTestId ? `${dataTestId}-decrement` : undefined}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -93,7 +94,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         −
       </Box>
       <Box
-        data-id={dataId ? `${dataId}-value` : undefined}
+        data-testid={dataTestId ? `${dataTestId}-value` : undefined}
         sx={{
           minWidth: dim,
           height: dim,
@@ -115,7 +116,7 @@ export const NumberStepper: React.FC<NumberStepperProps> = ({
         role="button"
         tabIndex={disabled ? -1 : 0}
         aria-label="Increase"
-        data-id={dataId ? `${dataId}-increment` : undefined}
+        data-testid={dataTestId ? `${dataTestId}-increment` : undefined}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();

--- a/src/components/PinCommentInput/index.tsx
+++ b/src/components/PinCommentInput/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Stack, Box, styled, SxProps, Theme } from "@mui/material";
 import { neutral, primary } from "../../theme/tokens/colors";
 import { theme } from "../../theme";
-import type { DataIdProps } from "../../constants";
+import type { DataTestIdProps } from "../../constants";
 
 // Borderless transparent text input filling the pill; italic grey placeholder.
 const Field = styled("input")({
@@ -17,10 +17,10 @@ const Field = styled("input")({
 });
 
 /**
- * Props for {@link PinCommentInput}. `data-id` lands on the `<input>`; the send
- * button gets `{data-id}-send`.
+ * Props for {@link PinCommentInput}. `data-testid` lands on the `<input>`; the
+ * send button gets `{data-testid}-send`.
  */
-export interface PinCommentInputProps extends DataIdProps {
+export interface PinCommentInputProps extends DataTestIdProps {
   /** Current comment text (controlled). */
   value: string;
   /** Fired with the new text on every keystroke. */
@@ -43,7 +43,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
   onSend,
   placeholder = "Add a Comment",
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   const hasText = value.trim().length > 0;
   return (
@@ -61,7 +61,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
       }}
     >
       <Field
-        data-id={dataId}
+        data-testid={dataTestId}
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
@@ -71,7 +71,7 @@ export const PinCommentInput: React.FC<PinCommentInputProps> = ({
       />
       <Box
         onClick={() => hasText && onSend?.()}
-        data-id={dataId ? `${dataId}-send` : undefined}
+        data-testid={dataTestId ? `${dataTestId}-send` : undefined}
         sx={{
           width: 28,
           height: 28,

--- a/src/components/PinInput/index.tsx
+++ b/src/components/PinInput/index.tsx
@@ -1,14 +1,14 @@
 import React, { useRef } from "react";
 import { Stack, Box, styled, SxProps, Theme } from "@mui/material";
-import { HEIGHTS, ComponentSize, type DataIdProps } from "../../constants";
+import { HEIGHTS, ComponentSize, type DataTestIdProps } from "../../constants";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
 
 /**
- * Props for the {@link PinInput} OTP / PIN entry component. `data-id` lands on
- * the root; each digit cell gets `{data-id}-{index}` (0-based).
+ * Props for the {@link PinInput} OTP / PIN entry component. `data-testid` lands
+ * on the root; each digit cell gets `{data-testid}-{index}` (0-based).
  */
-export interface PinInputProps extends DataIdProps {
+export interface PinInputProps extends DataTestIdProps {
   /** Number of cells */
   length?: number;
   /** Current value */
@@ -59,7 +59,7 @@ export const PinInput: React.FC<PinInputProps> = ({
   size = "large",
   disabled = false,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   const refs = useRef<Array<HTMLInputElement | null>>([]);
   const dim = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -88,7 +88,7 @@ export const PinInput: React.FC<PinInputProps> = ({
       alignItems="center"
       gap="8px"
       sx={sx}
-      data-id={dataId}
+      data-testid={dataTestId}
     >
       {Array.from({ length }).map((_, i) => (
         <React.Fragment key={i}>
@@ -105,7 +105,7 @@ export const PinInput: React.FC<PinInputProps> = ({
             ref={(el: HTMLInputElement | null) => {
               refs.current[i] = el;
             }}
-            data-id={dataId ? `${dataId}-${i}` : undefined}
+            data-testid={dataTestId ? `${dataTestId}-${i}` : undefined}
             inputMode="numeric"
             maxLength={1}
             disabled={disabled}

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
-import { withDataId, type DataIdProps } from "../../constants";
+import { withDataTestId, type DataTestIdProps } from "../../constants";
 
 /** Internal magnifier (leading) icon; `size` px and `color` default to the DS grey-400. */
 // Magnifier (leading) icon
@@ -59,12 +59,12 @@ const ClearIcon: React.FC<{ size?: number; color?: string }> = ({
 
 /**
  * Props for {@link SearchInput}; extends MUI `TextFieldProps` (minus its own
- * `onChange`/`value`). `data-id` lands on the `<input>`; the clear button gets
- * `{data-id}-clear`.
+ * `onChange`/`value`). `data-testid` lands on the `<input>`; the clear button
+ * gets `{data-testid}-clear`.
  */
 export interface SearchInputProps
   extends Omit<TextFieldProps, "onChange" | "value">,
-    DataIdProps {
+    DataTestIdProps {
   /** Current search value */
   value?: string;
   /** Callback when search value changes */
@@ -108,7 +108,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   size = "small",
   containerSx = {},
   onClear,
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...rest
 }) => {
   const [internalValue, setInternalValue] = useState(controlledValue ?? "");
@@ -182,7 +182,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
                 onClick={handleClear}
                 edge="end"
                 aria-label="clear search"
-                data-id={dataId ? `${dataId}-clear` : undefined}
+                data-testid={dataTestId ? `${dataTestId}-clear` : undefined}
                 disableRipple
               >
                 <ClearIcon size={iconPx} />
@@ -205,7 +205,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         ...containerSx,
       }}
       {...rest}
-      inputProps={withDataId(rest.inputProps, dataId)}
+      inputProps={withDataTestId(rest.inputProps, dataTestId)}
     />
   );
 };

--- a/src/components/SegmentedToggle/index.tsx
+++ b/src/components/SegmentedToggle/index.tsx
@@ -4,7 +4,7 @@ import {
   HEIGHTS,
   FontSizeMap,
   ComponentSize,
-  type DataIdProps,
+  type DataTestIdProps,
 } from "../../constants";
 import { theme } from "../../theme";
 
@@ -19,10 +19,10 @@ export interface SegmentedToggleOption {
 }
 
 /**
- * Props for {@link SegmentedToggle}. `data-id` lands on the root; each segment
- * gets `{data-id}-{option.value}`.
+ * Props for {@link SegmentedToggle}. `data-testid` lands on the root; each
+ * segment gets `{data-testid}-{option.value}`.
  */
-export interface SegmentedToggleProps extends DataIdProps {
+export interface SegmentedToggleProps extends DataTestIdProps {
   /** Segments */
   options: SegmentedToggleOption[];
   /** Currently selected value */
@@ -49,7 +49,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
   size = "medium",
   disabled = false,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
 }) => {
   // Scale the button-matched height by the app-provided `--scale` CSS var.
   const height = `calc(${HEIGHTS[size]} * var(--scale, 1))`;
@@ -59,7 +59,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
     <Stack
       direction="row"
       alignItems="center"
-      data-id={dataId}
+      data-testid={dataTestId}
       sx={{
         height,
         p: "2px",
@@ -83,7 +83,7 @@ export const SegmentedToggle: React.FC<SegmentedToggleProps> = ({
             justifyContent="center"
             gap="6px"
             onClick={() => onChange(opt.value)}
-            data-id={dataId ? `${dataId}-${opt.value}` : undefined}
+            data-testid={dataTestId ? `${dataTestId}-${opt.value}` : undefined}
             sx={{
               height: "100%",
               px: "12px",

--- a/src/components/SelectInput/index.tsx
+++ b/src/components/SelectInput/index.tsx
@@ -18,7 +18,7 @@ import {
 import { styled } from "@mui/material/styles";
 import theme from "@/theme";
 import { ArrowDown2, CheckIcon } from "@/icons";
-import { withDataId, type DataIdProps } from "../../constants";
+import { withDataTestId, type DataTestIdProps } from "../../constants";
 import SearchInput from "../SearchInput";
 
 export type Option = {
@@ -30,14 +30,15 @@ export type Option = {
 /**
  * Props for {@link SelectInput}.
  *
- * `data-id` lands on the trigger `<input>`; option rows get
- * `{data-id}-option-{value}` and the in-menu search box `{data-id}-search`.
+ * `data-testid` lands on the trigger `<input>`; option rows get
+ * `{data-testid}-option-{value}` and the in-menu search box
+ * `{data-testid}-search`.
  */
 export type SelectInputProps<T = unknown> = Omit<
   SelectProps<T>,
   "renderValue"
 > &
-  DataIdProps & {
+  DataTestIdProps & {
     label?: string;
     helperText?: React.ReactNode;
     options?: Option[];
@@ -99,7 +100,7 @@ export const SelectInput = <T = unknown,>({
   menuItemSx,
   disabled = false,
   readOnly = false,
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }: SelectInputProps<T>) => {
   const [searchTerm, setSearchTerm] = useState("");
@@ -200,7 +201,7 @@ export const SelectInput = <T = unknown,>({
               error={props.error}
               // Merge, don't replace: `params.inputProps` carries the
               // Autocomplete's combobox a11y wiring and change handlers.
-              inputProps={withDataId(params.inputProps, dataId)}
+              inputProps={withDataTestId(params.inputProps, dataTestId)}
               InputProps={{
                 ...params.InputProps,
                 startAdornment: startAdornment ? (
@@ -256,7 +257,9 @@ export const SelectInput = <T = unknown,>({
             <MenuItem
               key={key}
               {...optionProps}
-              data-id={dataId ? `${dataId}-option-${option.value}` : undefined}
+              data-testid={
+                dataTestId ? `${dataTestId}-option-${option.value}` : undefined
+              }
               sx={{
                 height: "calc(28px * var(--scale))",
                 minHeight: "auto",
@@ -331,7 +334,7 @@ export const SelectInput = <T = unknown,>({
               <Box ref={searchRef} sx={{ marginBottom: "4px" }}>
                 <SearchInput
                   autoFocus
-                  data-id={dataId ? `${dataId}-search` : undefined}
+                  data-testid={dataTestId ? `${dataTestId}-search` : undefined}
                   inputRef={searchInputRef}
                   size='small'
                   value={searchTerm}

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -8,14 +8,16 @@ import {
 } from "@mui/material";
 import { theme } from "../../theme";
 import { shadows } from "../../theme/tokens/shadows";
-import { withDataIdSlot, type DataIdProps } from "../../constants";
+import { withDataTestIdSlot, type DataTestIdProps } from "../../constants";
 
 /**
  * Props for {@link Switch}; extends MUI `SwitchProps` (minus `color`) with an
- * optional label. `data-id` lands on the underlying `<input type="checkbox">`,
- * not the styled track/thumb span.
+ * optional label. `data-testid` lands on the underlying
+ * `<input type="checkbox">`, not the styled track/thumb span.
  */
-export interface FsSwitchProps extends Omit<SwitchProps, "color">, DataIdProps {
+export interface FsSwitchProps
+  extends Omit<SwitchProps, "color">,
+    DataTestIdProps {
   /** Optional label rendered beside the switch */
   label?: React.ReactNode;
   /** Wrapper styles when a label is present */
@@ -30,7 +32,7 @@ export const Switch: React.FC<FsSwitchProps> = ({
   label,
   wrapperSx,
   sx,
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }) => {
   const control = (
@@ -60,7 +62,7 @@ export const Switch: React.FC<FsSwitchProps> = ({
       // so `role="switch"` has to be re-supplied here or it is lost.
       slotProps={{
         ...props.slotProps,
-        input: withDataIdSlot(props.slotProps?.input, dataId, {
+        input: withDataTestIdSlot(props.slotProps?.input, dataTestId, {
           role: "switch",
         }),
       }}

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { TextField, TextFieldProps, SxProps, Theme } from "@mui/material";
 import { theme } from "../../theme";
-import { withDataId, type DataIdProps } from "../../constants";
+import { withDataTestId, type DataTestIdProps } from "../../constants";
 
 /**
  * Props for {@link TextArea}; all MUI `TextField` props except `multiline`
- * (always on), plus row bounds. `data-id` lands on the `<textarea>` element.
+ * (always on), plus row bounds. `data-testid` lands on the `<textarea>`
+ * element.
  */
 export interface TextAreaProps
   extends Omit<TextFieldProps, "multiline">,
-    DataIdProps {
+    DataTestIdProps {
   /** Minimum number of visible text rows before the field grows. Defaults to 4. */
   minRows?: number;
   /** Maximum number of visible text rows; beyond this the field scrolls. Unbounded if omitted. */
@@ -26,7 +27,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
   minRows = 4,
   maxRows,
   sx = {},
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }) => {
   return (
@@ -49,7 +50,7 @@ export const TextArea: React.FC<TextAreaProps> = ({
         ...sx,
       }}
       {...props}
-      inputProps={withDataId(props.inputProps, dataId)}
+      inputProps={withDataTestId(props.inputProps, dataTestId)}
     />
   );
 };

--- a/src/components/TextInput/index.tsx
+++ b/src/components/TextInput/index.tsx
@@ -11,11 +11,13 @@ import {
   Theme,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { withDataId, type DataIdProps } from "../../constants";
+import { withDataTestId, type DataTestIdProps } from "../../constants";
 
-/** Props for {@link TextInput}. `data-id` lands on the `<input>` element. */
+/**
+ * Props for {@link TextInput}. `data-testid` lands on the `<input>` element.
+ */
 export type TextInputProps = TextFieldProps &
-  DataIdProps & {
+  DataTestIdProps & {
     label?: string;
     startAdornment?: React.ReactNode;
     endAdornment?: React.ReactNode;
@@ -58,7 +60,7 @@ export const TextInput = ({
   inputSx,
   helperTextSx,
   sx,
-  "data-id": dataId,
+  "data-testid": dataTestId,
   ...props
 }: TextInputProps) => {
   return (
@@ -75,7 +77,7 @@ export const TextInput = ({
           error={error}
           {...props}
           sx={inputSx}
-          inputProps={withDataId(props.inputProps, dataId)}
+          inputProps={withDataTestId(props.inputProps, dataTestId)}
           InputProps={{
             readOnly,
             ...props.InputProps,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,35 +14,37 @@ export type ComponentVariant = "round" | "rectangular";
  *
  * Each control renders the value on exactly one element — the focusable
  * `<input>` when it owns a single one, otherwise its root — so a
- * `[data-id="x"]` selector never matches twice. Composite controls (segments,
- * PIN cells, stepper buttons, option rows) additionally stamp suffixed ids
- * (`x-increment`, `x-option-2`, …) on their interactive children; each
- * component's TSDoc lists the suffixes it emits.
+ * `[data-testid="x"]` selector never matches twice. Composite controls
+ * (segments, PIN cells, stepper buttons, option rows) additionally stamp
+ * suffixed ids (`x-increment`, `x-option-2`, …) on their interactive children;
+ * each component's TSDoc lists the suffixes it emits.
  *
  * Declared explicitly because most of these components have closed prop
  * interfaces that drop unknown props. TypeScript also skips type-checking
- * hyphenated JSX attributes, so an unsupported `data-id` fails silently —
+ * hyphenated JSX attributes, so an unsupported `data-testid` fails silently —
  * hence the explicit prop rather than relying on rest-prop spreading.
  */
-export interface DataIdProps {
-  /** Rendered as the `data-id` DOM attribute for test/analytics targeting. */
-  "data-id"?: string;
+export interface DataTestIdProps {
+  /** Rendered as the `data-testid` DOM attribute for test targeting. */
+  "data-testid"?: string;
 }
 
 /**
- * Merges a `data-id` into a component's `inputProps` bag, preserving whatever
- * the caller already put there.
+ * Merges a `data-testid` into a component's `inputProps` bag, preserving
+ * whatever the caller already put there.
  *
  * The assertion is load-bearing: MUI types some `inputProps` slots as
  * `InputHTMLAttributes<HTMLInputElement>` (Checkbox, Radio, Switch), and an
  * object literal with a hyphenated key trips excess-property checking there.
  * JSX attributes are exempt from that check; object literals are not.
  */
-export const withDataId = <T,>(inputProps: T | undefined, dataId?: string): T =>
-  ({ ...inputProps, "data-id": dataId }) as T;
+export const withDataTestId = <T,>(
+  inputProps: T | undefined,
+  dataTestId?: string,
+): T => ({ ...inputProps, "data-testid": dataTestId }) as T;
 
 /**
- * Same as {@link withDataId}, for MUI's `slotProps.input` channel — which
+ * Same as {@link withDataTestId}, for MUI's `slotProps.input` channel — which
  * accepts either an object or an `ownerState` callback, so both forms have to
  * survive the merge.
  *
@@ -52,15 +54,15 @@ export const withDataId = <T,>(inputProps: T | undefined, dataId?: string): T =>
  * lose — passing `slotProps.input` to `Switch` replaces its `role="switch"`
  * wholesale rather than merging into it.
  */
-export const withDataIdSlot = <S extends object, O>(
+export const withDataTestIdSlot = <S extends object, O>(
   slot: S | ((ownerState: O) => S) | undefined,
-  dataId: string | undefined,
+  dataTestId: string | undefined,
   base?: object,
 ): S | ((ownerState: O) => S) =>
   typeof slot === "function"
     ? (ownerState: O) =>
-        ({ ...base, ...slot(ownerState), "data-id": dataId }) as S
-    : ({ ...base, ...slot, "data-id": dataId }) as S;
+        ({ ...base, ...slot(ownerState), "data-testid": dataTestId }) as S
+    : ({ ...base, ...slot, "data-testid": dataTestId }) as S;
 
 /** Control heights per {@link ComponentSize} (px, before `--scale`). */
 export const HEIGHTS: Record<ComponentSize, string> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,7 +392,7 @@ export {
   Colors,
   type ComponentSize,
   type ComponentVariant,
-  type DataIdProps,
+  type DataTestIdProps,
 } from './constants'
 
 // Icons


### PR DESCRIPTION
…documentation

- Updated all components to use `data-testid` instead of `data-id` for better test targeting.
- Modified related prop types from `DataIdProps` to `DataTestIdProps`.
- Adjusted documentation to reflect the changes in data attributes.
- Ensured that all instances of `data-id` in the codebase are replaced with `data-testid`, including in props, attributes, and helper functions.